### PR TITLE
136 fix current auth bugs before migration

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -6,6 +6,7 @@ import { AuthRepository } from "../repositories/auth.repository";
 import { LoginService } from "../services/login.service";
 import { LoginRepository } from "../repositories/login.repository";
 import { CreateAuthDTO } from "@civickit/shared";
+import { AppError } from "../utils/errors";
 
 const authRepository = new AuthRepository();
 const authService = new AuthService(authRepository);
@@ -19,6 +20,15 @@ export class AuthController {
       await authService.registerUser({ email, password, name });
       const loginResponse = await loginService.login({ email, password }); //lets the user login immediately after registering, instead of having to call the login endpoint separately
       return res.status(201).json(loginResponse);
+    } catch (error: any) {
+      next(error);
+    }
+  }
+
+  async getUserByToken(req: Request, res: Response, next: NextFunction) {
+    try {
+      const user = await authService.getUserByToken(String(req.query.token));
+      res.json(user);
     } catch (error: any) {
       next(error);
     }

--- a/backend/src/controllers/login.controller.ts
+++ b/backend/src/controllers/login.controller.ts
@@ -16,8 +16,9 @@ export class LoginController {
       }
 
       const user = await loginService.login(loginDTO);
-      res.json(user);
-    } catch (error) {
+      res.status(200).json(user);
+    } catch (error: any) {
+      res.status(error.statusCode);
       next(error);
     }
   }

--- a/backend/src/controllers/login.controller.ts
+++ b/backend/src/controllers/login.controller.ts
@@ -18,6 +18,7 @@ export class LoginController {
       const user = await loginService.login(loginDTO);
       res.status(200).json(user);
     } catch (error: any) {
+      res.status(error.statusCode);
       next(error);
     }
   }

--- a/backend/src/controllers/login.controller.ts
+++ b/backend/src/controllers/login.controller.ts
@@ -18,7 +18,6 @@ export class LoginController {
       const user = await loginService.login(loginDTO);
       res.status(200).json(user);
     } catch (error: any) {
-      res.status(error.statusCode);
       next(error);
     }
   }

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -34,7 +34,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
 
     //Verify Token
     const secret = String(process.env.JWT_SECRET)
-    if (!secret) {
+    if (secret == undefined) {
       return res.status(500).json({ error: 'JWT secret not configured' });
     }
 

--- a/backend/src/middleware/error.middleware.ts
+++ b/backend/src/middleware/error.middleware.ts
@@ -23,7 +23,7 @@ export const errorHandler = (
     console.error(`Time: ${new Date().toISOString()}`);
     console.error(`Method: ${req.method}`);
     console.error(`Path: ${req.originalUrl}`);
-    console.error(err.stack);
+    console.error(err.message);
     console.error('--- ERROR END ---');
 
     // Send safe response to client

--- a/backend/src/repositories/auth.repository.ts
+++ b/backend/src/repositories/auth.repository.ts
@@ -19,4 +19,21 @@ export class AuthRepository {
       data,
     });
   }
+
+  async findById(id: string) {
+
+    const user = await prisma.user.findUnique({
+      where: { id }
+    });
+
+    if (user != null) {
+      return {
+        id: user?.id, email: user?.email,
+        name: user?.name, passwordHash: user?.passwordHash,
+        profileImage: user?.profileImage, createdAt: user?.createdAt
+      }
+    }
+
+    return null
+  }
 }

--- a/backend/src/repositories/login.repository.ts
+++ b/backend/src/repositories/login.repository.ts
@@ -9,10 +9,14 @@ export class LoginRepository {
       where: { email }
     });
 
-    return {
-      id: user?.id, email: user?.email,
-      name: user?.name, passwordHash: user?.passwordHash,
-      profileImage: user?.profileImage, createdAt: user?.createdAt
+    if (user != null) {
+      return {
+        id: user?.id, email: user?.email,
+        name: user?.name, passwordHash: user?.passwordHash,
+        profileImage: user?.profileImage, createdAt: user?.createdAt
+      }
     }
+
+    return null
   }
 }

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -15,5 +15,6 @@ const limiter = RateLimit({
 router.use(limiter)
 
 router.post("/register", authController.register.bind(authController));
+router.get('/user', authController.getUserByToken);
 
 export default router;

--- a/backend/src/services/__tests__/unit/auth.service.test.ts
+++ b/backend/src/services/__tests__/unit/auth.service.test.ts
@@ -4,6 +4,7 @@ import { AuthService } from '../../auth.service';
 import { AuthRepository } from '../../../repositories/auth.repository';
 import { describe, beforeEach, vi, it, expect, Mocked } from 'vitest';
 import bcrypt from 'bcryptjs';
+import { AppError } from '../../../utils/errors';
 
 // mock repository
 vi.mock('../../../src/repositories/auth.repository');
@@ -68,10 +69,8 @@ describe('AuthService', () => {
                 password: 'password123',
                 name: 'Test',
             })
-        ).rejects.toEqual({
-            status: 400,
-            message: 'Invalid email format',
-        });
+        ).rejects.toEqual(
+            new AppError("Invalid email format", 400));
     });
 
     it('should throw error for short password', async () => {
@@ -81,10 +80,8 @@ describe('AuthService', () => {
                 password: 'short',
                 name: 'Test',
             })
-        ).rejects.toEqual({
-            status: 400,
-            message: 'Password too short (min 8 characters)',
-        });
+        ).rejects.toEqual(
+            new AppError('Password too short (min 8 characters)', 400));
     });
 
     it('should throw error if email already exists', async () => {
@@ -104,9 +101,7 @@ describe('AuthService', () => {
                 password: 'password123',
                 name: 'Test',
             })
-        ).rejects.toEqual({
-            status: 409,
-            message: 'Email already exists',
-        });
+        ).rejects.toEqual(
+            new AppError("Email already exists", 409));
     });
 });

--- a/backend/src/services/__tests__/unit/login.service.test.ts
+++ b/backend/src/services/__tests__/unit/login.service.test.ts
@@ -5,6 +5,7 @@ import { LoginRepository } from '../../../repositories/login.repository';
 import { describe, beforeEach, vi, it, expect, Mocked, Mock } from 'vitest';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import { AppError } from '../../../utils/errors';
 
 // mock repository
 vi.mock('../../../src/repositories/login.repository');
@@ -93,10 +94,10 @@ describe('LoginService', () => {
                 email: 'notfound@example.com',
                 password: 'password123',
             })
-        ).rejects.toEqual({
-            status: 401,
-            message: 'Email not found',
-        });
+        ).rejects.toEqual(new AppError(
+            'Email not found',
+            401
+        ))
     });
 
     it('should throw error if password does not match', async () => {
@@ -110,9 +111,7 @@ describe('LoginService', () => {
                 email: 'test@example.com',
                 password: 'wrongpassword',
             })
-        ).rejects.toEqual({
-            status: 401,
-            message: 'Password and email do not match',
-        });
+        ).rejects.toEqual(
+            new AppError("Password and email do not match", 401));
     });
 });

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -5,6 +5,7 @@ import { AuthRepository } from "../repositories/auth.repository";
 import { CreateAuthDTO } from "@civickit/shared";
 import { SafeUser } from '../types/auth.types'
 import { z } from 'zod';
+import { AppError } from "../utils/errors";
 
 export class AuthService {
   constructor(private authRepository: AuthRepository) { }
@@ -15,18 +16,18 @@ export class AuthService {
     // Validate email format
     const emailSchema = z.email();
     if (!emailSchema.safeParse(email).success) {
-      throw { status: 400, message: "Invalid email format" };
+      throw new AppError("Invalid email format", 400);
     }
 
     // Validate password length
     if (password.length < 8) {
-      throw { status: 400, message: "Password too short (min 8 characters)" };
+      throw new AppError("Password too short (min 8 characters)", 400);
     }
 
     // Check for existing user
     const existingUser = await this.authRepository.findByEmail(email);
     if (existingUser) {
-      throw { status: 409, message: "Email already exists" };
+      throw new AppError("Email already exists", 409);
     }
 
     // Hash password

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -5,6 +5,7 @@ import { AuthRepository } from "../repositories/auth.repository";
 import { CreateAuthDTO } from "@civickit/shared";
 import { SafeUser } from '../types/auth.types'
 import { z } from 'zod';
+import jwt, { JwtPayload } from 'jsonwebtoken';
 import { AppError } from "../utils/errors";
 
 export class AuthService {
@@ -43,5 +44,25 @@ export class AuthService {
     // Remove passwordHash before returning
     const { passwordHash: _, ...safeUser } = newUser;
     return safeUser;
+  }
+
+  async getUserByToken(token: string) {
+    const secret = String(process.env.JWT_SECRET)
+    if (secret == undefined) {
+      throw new AppError("JWT secret not configured", 500);
+    }
+    try {
+      const tokenResponse = jwt.verify(token, secret) as JwtPayload
+      const id = tokenResponse.userId
+
+      const user = await this.authRepository.findById(id);
+      if (!user) {
+        throw new AppError('User not found', 404);
+      }
+      return user
+    } catch (error) {
+      throw new AppError("Invalid token", 401)
+    }
+
   }
 }

--- a/backend/src/services/login.service.ts
+++ b/backend/src/services/login.service.ts
@@ -5,20 +5,23 @@ import jwt from "jsonwebtoken";
 import { LoginRepository } from '../repositories/login.repository';
 import { LoginDTO, LoginResponse } from "@civickit/shared";
 import "dotenv/config";
+import { AppError } from "../utils/errors";
 
 export class LoginService {
   constructor(private loginRepository: LoginRepository) { }
 
-  async login(credentials: LoginDTO): Promise<LoginResponse> {
+  async login(credentials: LoginDTO): Promise<LoginResponse | AppError> {
     const user = await this.loginRepository.findByEmail(credentials.email);
-    if (!user) {
-      throw { status: 401, message: 'Email not found' };
+
+    if (user == null) {
+      //TODO: fix to throw AppError
+      throw new AppError('Email not found', 401);
     }
 
     //compare user entered pw with pw hash from repo
     const match = await bcrypt.compare(credentials.password, String(user.passwordHash))
     if (!match) {
-      throw { status: 401, message: 'Password and email do not match' };
+      throw new AppError('Password and email do not match', 401);
     }
 
     //generate token with user id

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -24,6 +24,7 @@ import LandingScreenNav from './src/screens/Landing/LandingScreenNav';
 import FeedNav from './src/screens/Feed/FeedNav';
 import Button from './src/components/Button';
 import ProfileNav from './src/screens/Profile/ProfileNav';
+import LoadingScreen from './src/screens/Misc/LoadingScreen';
 
 const Tab = createBottomTabNavigator<TabParams>();
 
@@ -110,16 +111,15 @@ function MainTabNavigator() {
 }
 
 function AppNavigator() {
-  const { user, isLoading, authToken, login } = useAuth();
-  if (isLoading) return null; //or splash screen
-  console.log(authToken)
-  if (authToken != undefined) {
-    login(authToken)
-  }
+  const { isLoggedIn, isLoading } = useAuth();
+  console.log("logged in", isLoggedIn)
+  console.log("loading", isLoading)
+
+  if (isLoading) return <LoadingScreen />
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ animation: 'slide_from_right' }}>
-        {user != null ? (
+        {isLoggedIn ? (
           <>
             <Stack.Screen
               name="Main"
@@ -134,7 +134,7 @@ function AppNavigator() {
           </>
         )}
       </Stack.Navigator>
-      {user != null && <FlashMessage position="top" style={{ paddingTop: 32 }} />}
+      {isLoggedIn && <FlashMessage position="top" style={{ paddingTop: 32 }} />}
     </NavigationContainer>
   )
 }

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -110,13 +110,16 @@ function MainTabNavigator() {
 }
 
 function AppNavigator() {
-  const { isLoggedIn, isLoading } = useAuth();
+  const { user, isLoading, authToken, login } = useAuth();
   if (isLoading) return null; //or splash screen
-  console.log(isLoggedIn)
+  console.log(authToken)
+  if (authToken != undefined) {
+    login(authToken)
+  }
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={{ animation: 'slide_from_right' }}>
-        {isLoggedIn ? (
+        {user != null ? (
           <>
             <Stack.Screen
               name="Main"
@@ -131,7 +134,7 @@ function AppNavigator() {
           </>
         )}
       </Stack.Navigator>
-      {isLoggedIn && <FlashMessage position="top" style={{ paddingTop: 32 }} />}
+      {user != null && <FlashMessage position="top" style={{ paddingTop: 32 }} />}
     </NavigationContainer>
   )
 }

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -112,8 +112,6 @@ function MainTabNavigator() {
 
 function AppNavigator() {
   const { isLoggedIn, isLoading } = useAuth();
-  console.log("logged in", isLoggedIn)
-  console.log("loading", isLoading)
 
   if (isLoading) return <LoadingScreen />
   return (

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -2,6 +2,8 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import { getToken, saveToken, deleteToken } from '../services/AuthService';
 import { User } from '@civickit/shared';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import ENV from "../config/env";
 
 interface AuthContextType {
     isLoggedIn: boolean;
@@ -20,16 +22,34 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [authToken, setAuthToken] = useState<string | null>(null);
     const [user, setUser] = useState<User | null>(null);
+    const queryClient = useQueryClient()
 
     // On mount, check for token to determine if user is logged in
     useEffect(() => {
         (async () => {
             const token = await getToken();
             setAuthToken(token);
-            setIsLoggedIn(!!token);
-            setIsLoading(false);
         })();
     }, []); //no dependencies bc it runs once on mount to check for token
+
+
+    const { data, error, refetch } = useQuery({
+        queryKey: ['user'],
+        queryFn: async () => {
+            const response = await fetch(
+                ENV.apiUrl + '/auth/user?token=' +
+                authToken
+            );
+            if (!response.ok) {
+                if (response.status == 401 || response.status == 404) {
+                    throw new Error('Invalid Token');
+                } else {
+                    throw new Error("Failed to Fetch")
+                }
+            }
+            return response.json()
+        },
+    }, queryClient);
 
     //login store token + update state
     const login = async (token: string) => {
@@ -41,8 +61,25 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const logout = async () => {
         await deleteToken();
         setAuthToken(null);
+        setUser(null)
         setIsLoggedIn(false);
     };
+
+    if (error != null && isLoading == true) {
+        logout()
+
+        console.log(error)
+        setIsLoading(false)
+    }
+
+    if (data != null && isLoading == true) {
+        setUser(data)
+        setIsLoggedIn(true)
+        setIsLoading(false)
+
+    }
+
+
 
     return (
         <AuthContext.Provider value={{ isLoggedIn, isLoading, authToken, login, logout, setUser, user }}>

--- a/mobile/src/screens/Login/RegisterScreen.tsx
+++ b/mobile/src/screens/Login/RegisterScreen.tsx
@@ -17,6 +17,7 @@ import { StackParams } from '../../types/StackParams';
 import { registerUser } from '../../services/AuthService';
 import { useAuth } from '../../contexts/AuthContext';
 import { globalStyles } from '../../styles';
+import { loginUser } from '../../services/AuthService';
 import { colors, spacing, typography, borderRadius } from '../../styles/theme';
 // Validation
 const isValidEmail = (email: string) =>
@@ -84,12 +85,16 @@ export default function RegisterScreen() {
     };
 
     // Submit 
+    const { setUser } = useAuth();
     const handleRegister = async () => {
         if (!validate()) return;
 
         try {
+            console.log("handling register")
             setIsLoading(true);
             const { token } = await registerUser(name.trim(), email.trim(), password);
+            const { user } = await loginUser(email.trim(), password);
+            setUser(user)
             await login(token);
         } catch (error: any) {
             setServerError(error.message);

--- a/mobile/src/screens/Profile/AvatarScreen.tsx
+++ b/mobile/src/screens/Profile/AvatarScreen.tsx
@@ -21,7 +21,6 @@ export default function AvatarScreen({ route }: Props) {
     const [submitAllowed, setSubmitAllowed] = useState<boolean>(false)
 
     const user = route.params.user
-    console.log(user)
 
     const handleCancel = () => {
 

--- a/mobile/src/screens/Profile/ProfileNav.tsx
+++ b/mobile/src/screens/Profile/ProfileNav.tsx
@@ -5,22 +5,12 @@ import ProfileScreen from './ProfileScreen';
 import ErrorScreen from '../Misc/ErrorScreen';
 import AvatarScreen from './AvatarScreen';
 import SettingsScreen from './SettingsScreen';
-import IconButton from '../../components/IconButton';
 import { Text, View, StyleSheet } from 'react-native';
-import { SettingsIcon } from '../../components/Icons';
-import { StackNavigationProp } from '@react-navigation/stack';
-import { useNavigation } from '@react-navigation/native';
 import { useAuth } from '../../contexts/AuthContext';
 import { palette, colors, globalStyles, size, spacing, typography, borderRadius } from "../../styles";
 import Button from '../../components/Button';
 import IssueDetailScreen from '../Misc/IssueDetailScreen';
 import LeaderBoardScreen from '../Misc/LeaderboardScreen';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import ENV from "../../config/env";
-import LoadingScreen from '../Misc/LoadingScreen';
-import { MessageView } from '../../components/MessageView';
-import { useEffect, useState } from 'react';
-
 const Stack = createNativeStackNavigator<StackParams>();
 
 export default function ProfileNav() {

--- a/mobile/src/screens/Profile/ProfileNav.tsx
+++ b/mobile/src/screens/Profile/ProfileNav.tsx
@@ -24,10 +24,8 @@ import { useEffect, useState } from 'react';
 const Stack = createNativeStackNavigator<StackParams>();
 
 export default function ProfileNav() {
-    const { authToken, user, setUser } = useAuth();
+    const { user } = useAuth();
     const { logout } = useAuth();
-    const queryClient = useQueryClient()
-    const [refreshing, setRefreshing] = useState(true)
 
 
     if (user == null) {

--- a/mobile/src/screens/Profile/ProfileNav.tsx
+++ b/mobile/src/screens/Profile/ProfileNav.tsx
@@ -15,14 +15,20 @@ import { palette, colors, globalStyles, size, spacing, typography, borderRadius 
 import Button from '../../components/Button';
 import IssueDetailScreen from '../Misc/IssueDetailScreen';
 import LeaderBoardScreen from '../Misc/LeaderboardScreen';
-
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import ENV from "../../config/env";
+import LoadingScreen from '../Misc/LoadingScreen';
+import { MessageView } from '../../components/MessageView';
+import { useEffect, useState } from 'react';
 
 const Stack = createNativeStackNavigator<StackParams>();
 
 export default function ProfileNav() {
-    const { user } = useAuth();
-    const navigation = useNavigation<StackNavigationProp<StackParams>>();
+    const { authToken, user, setUser } = useAuth();
     const { logout } = useAuth();
+    const queryClient = useQueryClient()
+    const [refreshing, setRefreshing] = useState(true)
+
 
     if (user == null) {
         return (

--- a/mobile/src/screens/Profile/ProfileScreen.tsx
+++ b/mobile/src/screens/Profile/ProfileScreen.tsx
@@ -27,7 +27,6 @@ export default function ProfileScreen() {
     }
 
     const navigation = useNavigation<StackNavigationProp<StackParams>>();
-
     const issuesQuery = useQuery({
         queryKey: ['issues', 'user'],
         queryFn: async () => {
@@ -98,18 +97,11 @@ export default function ProfileScreen() {
             </IconButton>
 
             <View style={styles.profilePicContainer}>
-                {user?.profileImage != null ?
-                    <Image
-                        source={require("../../../assets/avatars/greenAvatar.png")}
-                        style={styles.profilePic} /> :
-                    <TrashIcon />}
-                {/* Replace trashcan with User image once implemented */}
-                {/* <View style={styles.editButton}>
-                    <IconButton
-                        onPress={() => navigation.navigate("Avatar", { user: user })} style={{ height: size.xxl, ...globalStyles.shadow }}>
-                        <EditIcon color={colors.textContrast} size={typography.sizeXl} />
-                    </IconButton>
-                </View> */}
+
+                <Image
+                    source={require("../../../assets/avatars/greenAvatar.png")}
+                    style={styles.profilePic} />
+
             </View>
 
             <Text style={globalStyles.heading1}>{user?.name}</Text>


### PR DESCRIPTION
issue #136 

**Filed Modified:** 

**Backend**
* `backend/src/controllers/auth.controller.ts` - added `getUserByToken` function
* `backend/src/controllers/login.controller.ts` - added status code to response
* `backend/src/middleware/auth.middleware.ts` - added check for token being undefinded
* `backend/src/middleware/error.middleware.ts` - returns error message
* `backend/src/repositories/auth.repository.ts` - added `findById` function
* `backend/src/repositories/login.repository.ts` - added check for null user
* `backend/src/routes/auth.routes.ts` - added `getUserByToken` route
* `backend/src/services/auth.service.ts` - updated errors from generic objects to `AppError` objects, added `getUserByToken` function
* `backend/src/services/login.service.ts` -  updated errors from generic objects to `AppError` objects
* `backend/src/services/__tests__/unit/auth.service.test.ts` & `backend/src/services/__tests__/unit/login.service.test.ts` - changed relevant tests to check for `AppError` objects not generic objects

**Mobile**
* `mobile/App.tsx` - returns loading screen while `isLoading` is true
* `mobile/src/contexts/AuthContext.tsx` - on mount, queries `getUserByToken` route to verify the token and, if valid, get the associated user
* `mobile/src/screens/Login/RegisterScreen.tsx` - logs user after register


**To Test:** 
run `npm test` on backend to run automated tests
open on mobile and view new behavior. If not previously logged in (or previous token expired), should default to log in screen, otherwise will open on landing page, with user details in profile screen. 
Registering a new user should automatically log them in as well now. 