### PR TITLE
137 add better auth backend in parallel

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@better-auth/prisma-adapter": "^1.6.23",
         "@cloudinary/react": "^1.14.4",
         "@cloudinary/url-gen": "^1.22.0",
         "@prisma/adapter-pg": "^7.3.0",
@@ -18,6 +19,7 @@
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
         "bcryptjs": "^3.0.3",
+        "better-auth": "^1.6.23",
         "cloudinary": "^2.9.0",
         "cors": "^2.8.5",
         "express": "^5.2.1",
@@ -88,7 +90,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -98,7 +100,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -108,7 +110,7 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -124,7 +126,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -143,6 +145,151 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@better-auth/core": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.6.23.tgz",
+      "integrity": "sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.39.0",
+        "@standard-schema/spec": "^1.1.0",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@cloudflare/workers-types": ">=4",
+        "@opentelemetry/api": "^1.9.0",
+        "better-call": "1.3.7",
+        "jose": "^6.1.0",
+        "kysely": "^0.28.5 || ^0.29.0",
+        "nanostores": "^1.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/drizzle-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/drizzle-adapter/-/drizzle-adapter-1.6.23.tgz",
+      "integrity": "sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "drizzle-orm": "^0.45.2"
+      },
+      "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/kysely-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/kysely-adapter/-/kysely-adapter-1.6.23.tgz",
+      "integrity": "sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "kysely": "^0.28.17 || ^0.29.0"
+      },
+      "peerDependenciesMeta": {
+        "kysely": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/memory-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/memory-adapter/-/memory-adapter-1.6.23.tgz",
+      "integrity": "sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2"
+      }
+    },
+    "node_modules/@better-auth/mongo-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/mongo-adapter/-/mongo-adapter-1.6.23.tgz",
+      "integrity": "sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "mongodb": "^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "mongodb": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/prisma-adapter": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/prisma-adapter/-/prisma-adapter-1.6.23.tgz",
+      "integrity": "sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@prisma/client": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@better-auth/telemetry": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.6.23.tgz",
+      "integrity": "sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@better-auth/core": "^1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1"
+      }
+    },
+    "node_modules/@better-auth/utils": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.4.2.tgz",
+      "integrity": "sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.0.1"
+      }
+    },
+    "node_modules/@better-auth/utils/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@better-fetch/fetch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.3.1.tgz",
+      "integrity": "sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==",
+      "license": "MIT"
     },
     "node_modules/@civickit/shared": {
       "resolved": "../shared",
@@ -944,7 +1091,7 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -984,6 +1131,18 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
@@ -997,11 +1156,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.133.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
       "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -1134,6 +1302,20 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@prisma/config/node_modules/readdirp": {
@@ -1731,14 +1913,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tinyhttp/accepts": {
@@ -2040,7 +2221,7 @@
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
@@ -2078,14 +2259,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/express": {
@@ -2339,7 +2520,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
       "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -2357,7 +2538,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
       "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/spy": "4.1.8",
@@ -2384,7 +2565,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
       "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^3.1.0"
@@ -2397,7 +2578,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
       "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/utils": "4.1.8",
@@ -2411,7 +2592,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
       "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.8",
@@ -2427,7 +2608,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
       "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -2437,7 +2618,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
       "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "4.1.8",
@@ -2567,7 +2748,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2639,6 +2820,143 @@
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/better-auth": {
+      "version": "1.6.23",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.6.23.tgz",
+      "integrity": "sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/core": "1.6.23",
+        "@better-auth/drizzle-adapter": "1.6.23",
+        "@better-auth/kysely-adapter": "1.6.23",
+        "@better-auth/memory-adapter": "1.6.23",
+        "@better-auth/mongo-adapter": "1.6.23",
+        "@better-auth/prisma-adapter": "1.6.23",
+        "@better-auth/telemetry": "1.6.23",
+        "@better-auth/utils": "0.4.2",
+        "@better-fetch/fetch": "1.3.1",
+        "@noble/ciphers": "^2.1.1",
+        "@noble/hashes": "^2.0.1",
+        "better-call": "1.3.7",
+        "defu": "^6.1.4",
+        "jose": "^6.1.3",
+        "kysely": "^0.28.17 || ^0.29.0",
+        "nanostores": "^1.1.1",
+        "zod": "^4.3.6"
+      },
+      "peerDependencies": {
+        "@lynx-js/react": "*",
+        "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "@sveltejs/kit": "^2.0.0",
+        "@tanstack/react-start": "^1.0.0",
+        "@tanstack/solid-start": "^1.0.0",
+        "better-sqlite3": "^12.0.0",
+        "drizzle-kit": ">=0.31.4",
+        "drizzle-orm": "^0.45.2",
+        "mongodb": "^6.0.0 || ^7.0.0",
+        "mysql2": "^3.0.0",
+        "next": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "pg": "^8.0.0",
+        "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "solid-js": "^1.0.0",
+        "svelte": "^4.0.0 || ^5.0.0",
+        "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "vue": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@lynx-js/react": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "@tanstack/react-start": {
+          "optional": true
+        },
+        "@tanstack/solid-start": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "drizzle-kit": {
+          "optional": true
+        },
+        "drizzle-orm": {
+          "optional": true
+        },
+        "mongodb": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "solid-js": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/better-auth/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/better-call": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.3.7.tgz",
+      "integrity": "sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@better-auth/utils": "^0.4.0",
+        "@better-fetch/fetch": "^1.1.21",
+        "rou3": "^0.7.12",
+        "set-cookie-parser": "^3.0.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/better-result": {
@@ -2786,7 +3104,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2957,7 +3275,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -3123,7 +3441,6 @@
       "version": "6.1.6",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
       "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/delayed-stream": {
@@ -3165,7 +3482,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3334,7 +3651,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -3417,7 +3734,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -3448,7 +3765,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
@@ -3613,7 +3930,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -4337,6 +4654,15 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jq": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/jq/-/jq-1.7.2.tgz",
@@ -4495,6 +4821,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kysely": {
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
+      "integrity": "sha512-s6WVJyEZrbm6jhBpiKHsGHyePMrVQKJ85wZCFCr9W4QHv6WTjWIrdvTmO9hDEA3bNK0xkrE2DqrHsXMLWuZpQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
@@ -4505,7 +4840,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4873,7 +5208,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -4883,7 +5218,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
       "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
@@ -5105,7 +5440,7 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5118,6 +5453,21 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanostores": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/nanostores/-/nanostores-1.4.0.tgz",
+      "integrity": "sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
       }
     },
     "node_modules/negotiator": {
@@ -5205,7 +5555,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
       "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -5415,7 +5765,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5440,7 +5790,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5876,7 +6226,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
       "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.133.0",
@@ -5905,6 +6255,12 @@
         "@rolldown/binding-win32-arm64-msvc": "1.0.3",
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
+    },
+    "node_modules/rou3": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.7.12.tgz",
+      "integrity": "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -6018,6 +6374,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.1.tgz",
+      "integrity": "sha512-vM9SUhjsUYs6UeJUmygc5Ofm5eQGe85riob5ju6XCgFGJI5PLV4nrDAQpQjd+LkFBpAkADn5BQQpZ9EUNkyLuA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -6123,7 +6485,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/signal-exit": {
@@ -6253,7 +6615,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
@@ -6269,7 +6631,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/steno": {
@@ -6395,7 +6757,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
@@ -6412,7 +6774,7 @@
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6429,7 +6791,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
       "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -6812,7 +7174,7 @@
       "version": "8.0.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -6890,7 +7252,7 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
       "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@vitest/expect": "4.1.8",
@@ -6996,7 +7358,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "@better-auth/prisma-adapter": "^1.6.23",
     "@cloudinary/react": "^1.14.4",
     "@cloudinary/url-gen": "^1.22.0",
     "@prisma/adapter-pg": "^7.3.0",
@@ -40,6 +41,7 @@
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "bcryptjs": "^3.0.3",
+    "better-auth": "^1.6.23",
     "cloudinary": "^2.9.0",
     "cors": "^2.8.5",
     "express": "^5.2.1",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -37,59 +37,58 @@ enum EventStatus {
 }
 
 model User {
-  id            String   @id @default(cuid())
-  email         String   @unique
-  passwordHash  String
-  name          String
-  profileImage  String?
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  id           String   @id @default(cuid())
+  email        String   @unique
+  name         String
+  profileImage String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
 
-  issues        Issue[]
-  events        Event[]
-  comments      Comment[]
-  upvotes       Upvote[]
-  eventRsvps    EventRsvp[]
+  issues     Issue[]
+  events     Event[]
+  comments   Comment[]
+  upvotes    Upvote[]
+  eventRsvps EventRsvp[]
+
+  emailVerified Boolean   @default(false)
+  image         String?
+  sessions      Session[]
+  accounts      Account[]
 
   @@index([email])
+  @@map("user")
 }
 
 model Issue {
-  id          String        @id @default(cuid())
-  title       String
-  description String
-  category    IssueCategory
-  status      IssueStatus   @default(REPORTED)
-  
+  id                 String        @id @default(cuid())
+  title              String
+  description        String
+  category           IssueCategory
+  status             IssueStatus   @default(REPORTED)
   // Location data
-  latitude    Float
-  longitude   Float
-  address     String?
-  district    String?
-  subregion   String?
-  name        String?
-  
+  latitude           Float
+  longitude          Float
+  address            String?
+  district           String?
+  subregion          String?
+  name               String?
   // Media
-  images      String[]      // Array of Cloudinary URLs
-  
+  images             String[] // Array of Cloudinary URLs
   // Metadata
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
-  locationSource String     @default("device")
-  photoTakenAt DateTime?
-  photoTakenAtSource String @default("device")
-  
+  createdAt          DateTime      @default(now())
+  updatedAt          DateTime      @updatedAt
+  locationSource     String        @default("device")
+  photoTakenAt       DateTime?
+  photoTakenAtSource String        @default("device")
   // Relationships
-  userId      String
-  user        User          @relation(fields: [userId], references: [id])
-  
-  comments    Comment[]
-  upvotes     Upvote[]
-  events      Event[]
-  
+  userId             String
+  user               User          @relation(fields: [userId], references: [id])
+  comments           Comment[]
+  upvotes            Upvote[]
+  events             Event[]
   // City integration
-  cityRefNumber String?     // 311 reference number
-  
+  cityRefNumber      String? // 311 reference number
+
   @@index([latitude, longitude])
   @@index([status])
   @@index([category])
@@ -100,13 +99,11 @@ model Comment {
   id        String   @id @default(cuid())
   content   String
   createdAt DateTime @default(now())
-  
   issueId   String
   issue     Issue    @relation(fields: [issueId], references: [id], onDelete: Cascade)
-  
   userId    String
   user      User     @relation(fields: [userId], references: [id])
-  
+
   @@index([issueId])
   @@index([createdAt])
 }
@@ -114,60 +111,99 @@ model Comment {
 model Upvote {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
-  
   issueId   String
   issue     Issue    @relation(fields: [issueId], references: [id], onDelete: Cascade)
-  
   userId    String
   user      User     @relation(fields: [userId], references: [id])
-  
-  @@unique([issueId, userId]) // User can only upvote once
+
+  // User can only upvote once
+  @@unique([issueId, userId])
   @@index([issueId])
 }
 
 model Event {
-  id           String      @id @default(cuid())
-  title        String
-  description  String
-  status       EventStatus @default(PLANNED)
-  
+  id          String      @id @default(cuid())
+  title       String
+  description String
+  status      EventStatus @default(PLANNED)
   // Date/time
-  startTime    DateTime
-  endTime      DateTime
-  
+  startTime   DateTime
+  endTime     DateTime
   // Location
-  latitude     Float
-  longitude    Float
-  address      String
-  
+  latitude    Float
+  longitude   Float
+  address     String
   // Metadata
-  createdAt    DateTime    @default(now())
-  updatedAt    DateTime    @updatedAt
-  
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
   // Relationships
-  organizerId  String
-  organizer    User        @relation(fields: [organizerId], references: [id])
-  
-  issueId      String?     // Optional: event can be linked to an issue
-  issue        Issue?      @relation(fields: [issueId], references: [id])
-  
-  rsvps        EventRsvp[]
-  
+  organizerId String
+  organizer   User        @relation(fields: [organizerId], references: [id])
+  issueId     String? // Optional: event can be linked to an issue
+  issue       Issue?      @relation(fields: [issueId], references: [id])
+  rsvps       EventRsvp[]
+
   @@index([startTime])
   @@index([status])
 }
 
 model EventRsvp {
   id        String   @id @default(cuid())
-  status    String   // "GOING", "MAYBE", "NOT_GOING"
+  status    String // "GOING", "MAYBE", "NOT_GOING"
   createdAt DateTime @default(now())
-  
   eventId   String
   event     Event    @relation(fields: [eventId], references: [id], onDelete: Cascade)
-  
   userId    String
   user      User     @relation(fields: [userId], references: [id])
-  
+
   @@unique([eventId, userId])
   @@index([eventId])
+}
+
+model Session {
+  id        String   @id
+  expiresAt DateTime
+  token     String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  ipAddress String?
+  userAgent String?
+  userId    String
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([token])
+  @@index([userId])
+  @@map("session")
+}
+
+model Account {
+  id                    String    @id
+  accountId             String
+  providerId            String
+  userId                String
+  user                  User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  accessToken           String?
+  refreshToken          String?
+  idToken               String?
+  accessTokenExpiresAt  DateTime?
+  refreshTokenExpiresAt DateTime?
+  scope                 String?
+  password              String?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  @@index([userId])
+  @@map("account")
+}
+
+model Verification {
+  id         String   @id
+  identifier String
+  value      String
+  expiresAt  DateTime
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@index([identifier])
+  @@map("verification")
 }

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
   id           String   @id @default(cuid())
   email        String   @unique
   name         String
+  passwordHash String?
   profileImage String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,0 +1,15 @@
+import { betterAuth } from "better-auth";
+import { prismaAdapter } from "better-auth/adapters/prisma";
+import { PrismaClient } from "@prisma/client";
+import { Pool } from "pg";
+import { PrismaPg } from "@prisma/adapter-pg";
+import prisma from "./prisma";
+
+export const auth = betterAuth({
+    database: prismaAdapter(prisma, {
+        provider: "postgresql"
+    }),
+    emailAndPassword: {
+        enabled: true
+    }
+});

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,8 +1,5 @@
 import { betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
-import { PrismaClient } from "@prisma/client";
-import { Pool } from "pg";
-import { PrismaPg } from "@prisma/adapter-pg";
 import prisma from "./prisma";
 
 export const auth = betterAuth({

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -11,5 +11,6 @@ export const auth = betterAuth({
     }),
     emailAndPassword: {
         enabled: true
-    }
+    },
+    trustedOrigins: ["http://localhost:3001"],
 });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -30,13 +30,13 @@ app.all("/api/better-auth/auth/{*any}", toNodeHandler(auth));
 //     password: "password1234", // required
 //   },
 // });
-const data = await auth.api.signInEmail({
-  body: {
-    email: "john.doe1@example.com", // required
-    password: "password1234", // required
-  },
-});
-console.log(data)
+// const data = await auth.api.signInEmail({
+//   body: {
+//     email: "john.doe1@example.com", // required
+//     password: "password1234", // required
+//   },
+// });
+// console.log(data)
 
 // Middleware
 const corsOptions = {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -23,8 +23,18 @@ const PORT = Number(process.env.PORT) || 3000;
 
 //BetterAuth
 app.all("/api/better-auth/auth/{*any}", toNodeHandler(auth));
-// const data = await auth.api.signInEmail({
+const data = await auth.api.signInEmail({
+  body: {
+    email: "john.doe@example.com", // required
+    password: "password1234", // required
+  },
+});
+
+console.log(data)
+
+// const data = await auth.api.signUpEmail({
 //   body: {
+//     name: "John Doe", // required
 //     email: "john.doe@example.com", // required
 //     password: "password1234", // required
 //   },

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -12,11 +12,23 @@ import RateLimit from 'express-rate-limit';
 import { authMiddleware } from './middleware/auth.middleware';
 import { errorHandler } from './middleware/error.middleware';
 import { requestLogger } from './middleware/logger.middleware';
+import { toNodeHandler } from "better-auth/node";
+import { auth } from "./auth";
+import { isAPIError, } from "better-auth/api";
 
 dotenv.config();
 
 const app = express();
 const PORT = Number(process.env.PORT) || 3000;
+
+//BetterAuth
+app.all("/api/better-auth/auth/{*any}", toNodeHandler(auth));
+// const data = await auth.api.signInEmail({
+//   body: {
+//     email: "john.doe@example.com", // required
+//     password: "password1234", // required
+//   },
+// });
 
 // Middleware
 const corsOptions = {
@@ -64,5 +76,6 @@ app.use(errorHandler);
 
 app.listen(PORT, () => {
   console.log(`Server running on http://localhost:${PORT}`);
+  console.log(`Better Auth app listening on port ${PORT}`);
 });
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -23,22 +23,6 @@ const PORT = Number(process.env.PORT) || 3000;
 
 //BetterAuth
 app.all("/api/better-auth/auth/{*any}", toNodeHandler(auth));
-const data = await auth.api.signInEmail({
-  body: {
-    email: "john.doe@example.com", // required
-    password: "password1234", // required
-  },
-});
-
-console.log(data)
-
-// const data = await auth.api.signUpEmail({
-//   body: {
-//     name: "John Doe", // required
-//     email: "john.doe@example.com", // required
-//     password: "password1234", // required
-//   },
-// });
 
 // Middleware
 const corsOptions = {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -23,6 +23,20 @@ const PORT = Number(process.env.PORT) || 3000;
 
 //BetterAuth
 app.all("/api/better-auth/auth/{*any}", toNodeHandler(auth));
+// const data = auth.api.signUpEmail({
+//   body: {
+//     name: "John Doe", // required
+//     email: "john.doe1@example.com", // required
+//     password: "password1234", // required
+//   },
+// });
+const data = await auth.api.signInEmail({
+  body: {
+    email: "john.doe1@example.com", // required
+    password: "password1234", // required
+  },
+});
+console.log(data)
 
 // Middleware
 const corsOptions = {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "esnext",
+    "module": "ES2020",
     "moduleResolution": "bundler",
     "lib": [
       "ES2020"

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "ES2020",
+    "module": "esnext",
     "moduleResolution": "bundler",
     "lib": [
       "ES2020"
@@ -21,8 +21,9 @@
   },
   "include": [
     "src/**/*",
-    "tests/**/*"
-, "vitest.integration.config.js"  ],
+    "tests/**/*",
+    "vitest.integration.config.js"
+  ],
   "exclude": [
     "node_modules"
   ]


### PR DESCRIPTION
issue #137 

**Files Added:**
* `backend/src/auth.ts` - better auth configuration

**Filed Modified:** 
* `backend/prisma/schema.prisma` - updated schema to include better auth specifications
  * better auth distinguishes between `User` and `Account`, so the `passwordHash` field was made optional instead of required
* `backend/src/server.ts` - add better auth route

**Packages Added:** 
* `better-auth/prisma-adapter`
* `better-auth`

**To Test:** 
remigrate database with `npm run db:setup`

In `backend/src/server.ts`, add 
`const data = await auth.api.signUpEmail({
  body: {
    name: "John Doe",
    email: "john.doe1@example.com", 
    password: "password1234",
  },
});
console.log(data)`
to test registration.

add
`const data = await auth.api.signInEmail({
  body: {
    email: "john.doe1@example.com", 
    password: "password1234", 
  },
});
console.log(data)`
to test login

Note: because of the different password storage structures, better auth users and normal auth users are stored a little differently and thus don't currently work the same. So a user created with the better auth system can be logged in with the better auth system but not the current in place route. Vice versa, the better auth system can't log in a user registered through the current auth route.
