### PR TITLE
renamed feed to statistics

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -21,7 +21,7 @@ import React from 'react';
 import { LocationProvider } from './src/contexts/LocationContext';
 import { NearbyIssuesProvider } from './src/contexts/NearbyIssuesContext';
 import LandingScreenNav from './src/screens/Landing/LandingScreenNav';
-import FeedNav from './src/screens/Feed/FeedNav';
+import StatsNav from './src/screens/Stats/StatsNav';
 import Button from './src/components/Button';
 import ProfileNav from './src/screens/Profile/ProfileNav';
 import LoadingScreen from './src/screens/Misc/LoadingScreen';
@@ -57,7 +57,7 @@ function MainTabNavigator() {
               ),
               headerShown: false
             }} />
-          <Tab.Screen name="Feed Nav" component={FeedNav}
+          <Tab.Screen name="Stats Nav" component={StatsNav}
             options={{
               tabBarIcon: () => (
                 <SearchIcon

--- a/mobile/src/screens/Misc/LeaderboardScreen.tsx
+++ b/mobile/src/screens/Misc/LeaderboardScreen.tsx
@@ -1,4 +1,4 @@
-// mobile/src/screens/Feed/LeaderboardScreen.tsx
+// mobile/src/screens/Stats/LeaderboardScreen.tsx
 import { View, Text, FlatList, StyleSheet, ScrollView, RefreshControl } from "react-native";
 import { borderRadius, colors, globalStyles, palette, size, spacing, typography } from "../../styles";
 import ModalDropdown from "../../components/ModalDropdown";

--- a/mobile/src/screens/Profile/ProfileNav.tsx
+++ b/mobile/src/screens/Profile/ProfileNav.tsx
@@ -1,4 +1,4 @@
-// mobile/src/screens/Profile/FeedNav.tsx
+// mobile/src/screens/Profile/StatsNav.tsx
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StackParams } from '../../types/StackParams';
 import ProfileScreen from './ProfileScreen';

--- a/mobile/src/screens/Stats/StatsNav.tsx
+++ b/mobile/src/screens/Stats/StatsNav.tsx
@@ -1,15 +1,15 @@
-// mobile/src/screens/Feed/FeedNav.tsx
+// mobile/src/screens/Stats/StatsNav.tsx
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StackParams } from '../../types/StackParams';
 import { colors, typography } from '../../styles';
-import FeedScreen from './FeedScreen';
+import StatsScreen from './StatsScreen';
 import LeaderBoardScreen from '../Misc/LeaderboardScreen';
 import IssueDetailScreen from '../Misc/IssueDetailScreen';
 import ErrorScreen from '../Misc/ErrorScreen';
 
 const Stack = createNativeStackNavigator<StackParams>();
 
-export default function FeedNav() {
+export default function StatsNav() {
     return (
         <Stack.Navigator screenOptions={{
             headerStyle: {
@@ -23,7 +23,7 @@ export default function FeedNav() {
 
         }}
         >
-            <Stack.Screen name="Feed" component={FeedScreen}
+            <Stack.Screen name="Statistics" component={StatsScreen}
                 options={{
                     headerShown: true
                 }} />

--- a/mobile/src/screens/Stats/StatsScreen.tsx
+++ b/mobile/src/screens/Stats/StatsScreen.tsx
@@ -1,4 +1,4 @@
-// mobile/src/screens/Feed/FeedScreen.tsx
+// mobile/src/screens/Stats/StatsScreen.tsx
 import { MessageView } from "../../components/MessageView";
 import { Dimensions, RefreshControl, ScrollView, Text, StyleSheet, View } from "react-native"
 import { borderRadius, colors, globalStyles, size, spacing, typography } from "../../styles";
@@ -26,7 +26,7 @@ import Leaderboard from "../../components/Leaderboard";
 
 type record = Record<string, number>;
 
-export default function FeedScreen() {
+export default function StatsScreen() {
 
     const [refreshing, setRefreshing] = useState(false);
     const [radius, setRadius] = useState("1 mile")

--- a/mobile/src/types/StackParams.ts
+++ b/mobile/src/types/StackParams.ts
@@ -20,8 +20,8 @@ export type StackParams = {
         uri: string
         metadata?: PhotoMetadata
     },
-    "Feed": {},
-    "Feed Nav": {},
+    "Statistics": {},
+    "Stats Nav": {},
     "Leaderboard": {
         issues: any[]
         endorsementsOption?: boolean

--- a/mobile/src/types/TabParams.ts
+++ b/mobile/src/types/TabParams.ts
@@ -2,7 +2,7 @@
 
 export type TabParams = {
     "Map": {},
-    "Feed Nav": {},
+    "Stats Nav": {},
     "ReportIssue": {},
     "Events": {},
     "Profile Nav": {}


### PR DESCRIPTION
issue #163 

**What Was Changed**
Anywhere that references the feed screen was renamed to Stats, with the screen heading being "Statistics".

**To Test:** 
Launch app as normal. Only visible change is the screen heading. 