### PR TITLE
Advisor/001 verification baseline

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -28,5 +28,11 @@ jobs:
       - name: Generate Prisma Client
         run: npx prisma generate
 
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build
+
       - name: Run tests
         run: npm test

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,10 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "migrate:dev": "npx prisma migrate dev --name init --schema ./src/prisma/schema.prisma --config ./src/prisma.config.ts",
+    "migrate:dev": "npx prisma migrate dev --name init --schema ./prisma/schema.prisma --config ./prisma.config.ts",
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:studio": "prisma studio",

--- a/backend/src/services/__tests__/unit/auth.service.test.ts
+++ b/backend/src/services/__tests__/unit/auth.service.test.ts
@@ -42,7 +42,9 @@ describe('AuthService', () => {
             passwordHash: 'hashedPassword',
             profileImage: null,
             createdAt: new Date(),
-            updatedAt: new Date()
+            updatedAt: new Date(),
+            emailVerified: false,
+            image: null,
         });
 
         const result = await authService.registerUser({
@@ -92,7 +94,9 @@ describe('AuthService', () => {
             passwordHash: 'hashed',
             profileImage: null,
             createdAt: new Date(),
-            updatedAt: new Date()
+            updatedAt: new Date(),
+            emailVerified: false,
+            image: null,
         });
 
         await expect(


### PR DESCRIPTION
### Summary

The backend's `tsc` and `npm run build` were failing on `main`, and CI never noticed. This PR makes both pass and makes CI actually gate on them.

CI ran only `npm test`, and vitest uses esbuild (which strips TypeScript types without checking them). So a broken build stayed green indefinitely. Since `npm run build` (`tsc`) is what produces `dist/`, and `npm start` runs `node dist/server.js`, the backend was not deployable, and nothing in the dev loop (`tsx watch`, vitest) would ever have told us.

This is a prerequisite for the other queued backend work: without a green baseline, there's no way to tell whether a new change broke something or whether it was already broken.

### Files Modified

| File | Change |
|------|--------|
| `backend/src/services/__tests__/unit/auth.service.test.ts` | Added the missing `emailVerified: false` and `image: null` fields to the two mock `User` fixtures. The `User` model gained these fields during the BetterAuth work (`prisma/schema.prisma`), but the test fixtures were never updated, so they no longer satisfied the generated `User` type. This was the sole cause of both type errors. Assertions are unchanged — only the two fields were added. |
| `backend/package.json` | (1) Fixed `migrate:dev`, which pointed at `./src/prisma/schema.prisma` and `./src/prisma.config.ts` — neither path exists. Now points at the real `./prisma/schema.prisma` and `./prisma.config.ts`. The script was dead on arrival before this. (2) Added a `typecheck` script (`tsc --noEmit -p tsconfig.json`) for CI and local use. |
| `.github/workflows/backend.yml` | Added `Typecheck` and `Build` steps between "Generate Prisma Client" and "Run tests", so a broken build can no longer pass CI. |

### Before / after

| Command | Before | After |
|---------|--------|-------|
| `npx tsc --noEmit` | 2 errors (exit 2) | exit 0 |
| `npm run build` | fails, no `dist/` | exit 0, `dist/server.js` emitted |
| `npm test` | 35 pass | 35 pass (unchanged) |
| `npm run typecheck` | did not exist | exit 0 |
| CI | `npm test` only | typecheck + build + test |

The two errors this fixes:
src/services/tests/unit/auth.service.test.ts(38,57): error TS2345: ... is missing the following properties ...: image, emailVerified
src/services/tests/unit/auth.service.test.ts(88,58): error TS2345: ... is missing the following properties ...: image, emailVerified

### How to test
No database required — the unit tests inject mock repositories.
```bash
git checkout advisor/001-verification-baseline
cd backend
npm install
npx prisma generate
npm run typecheck   # expect: exit 0, no output
npm run build       # expect: exit 0
ls dist/server.js   # expect: file exists
npm test            # expect: 5 test files, 35 tests, all pass
To confirm the regression this fixes, check out main and run npx tsc --noEmit -p tsconfig.json in backend/ — it fails with the two errors above.

Do not run npm run migrate:dev as part of review; it needs a live database. The corrected paths can be verified by confirming backend/prisma/schema.prisma and backend/prisma.config.ts exist.

CI on this PR should now show four green steps (Generate Prisma Client, Typecheck, Build, Run tests). The Typecheck and Build steps are the new gate.