### PR TITLE
Advisor/002 harden jwt secret

### DIFF
--- a/backend/src/__tests__/setup-env.ts
+++ b/backend/src/__tests__/setup-env.ts
@@ -1,0 +1,4 @@
+// backend/src/__tests__/setup-env.ts
+// Seeds a FAKE secret for unit tests before any module imports config/env.ts.
+// This value is not a real credential and must never be used outside tests.
+process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-only-fake-secret-value-1234';

--- a/backend/src/config/__tests__/env.test.ts
+++ b/backend/src/config/__tests__/env.test.ts
@@ -1,0 +1,47 @@
+// backend/src/config/__tests__/env.test.ts
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { requireEnv } from '../env';
+
+describe('requireEnv', () => {
+    const testVarName = 'REQUIRE_ENV_TEST_VAR';
+
+    afterEach(() => {
+        delete process.env[testVarName];
+    });
+
+    it('returns the value when present and >= minLength', () => {
+        process.env[testVarName] = 'a-sufficiently-long-value';
+
+        const result = requireEnv(testVarName, 10);
+
+        expect(result).toBe('a-sufficiently-long-value');
+    });
+
+    it('throws when the variable is unset, and the message names the variable', () => {
+        expect(() => requireEnv('DEFINITELY_UNSET_VAR_FOR_TEST')).toThrow(
+            /DEFINITELY_UNSET_VAR_FOR_TEST/
+        );
+    });
+
+    it('throws when the variable is present but shorter than minLength', () => {
+        process.env[testVarName] = 'short';
+
+        expect(() => requireEnv(testVarName, 20)).toThrow();
+    });
+
+    it('does not include the variable value in the thrown message', () => {
+        const secretValue = 'super-secret-value-should-not-leak';
+        process.env[testVarName] = secretValue;
+
+        let thrown: unknown;
+        try {
+            requireEnv(testVarName, 1000);
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(Error);
+        expect((thrown as Error).message).not.toContain(secretValue);
+    });
+});

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -1,0 +1,20 @@
+// backend/src/config/env.ts
+
+/**
+ * Central, validated access to required environment variables.
+ * Throws at import time if a required secret is missing so the process
+ * fails closed instead of running with an insecure fallback.
+ */
+export function requireEnv(name: string, minLength = 1): string {
+  const value = process.env[name];
+  if (value === undefined || value.length < minLength) {
+    throw new Error(
+      `Environment variable ${name} is missing or too short ` +
+        `(min ${minLength} chars). Refusing to start.`,
+    );
+  }
+  return value;
+}
+
+// JWT secret must be present and reasonably long. Never log this value.
+export const JWT_SECRET = requireEnv('JWT_SECRET', 16);

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -2,6 +2,7 @@
 
 import { Request, Response, NextFunction } from 'express';
 import jwt, { JwtPayload } from 'jsonwebtoken';
+import { JWT_SECRET } from '../config/env';
 
 // Extend Express Request type
 declare global {
@@ -33,12 +34,7 @@ export const authMiddleware = (req: Request, res: Response, next: NextFunction) 
     }
 
     //Verify Token
-    const secret = String(process.env.JWT_SECRET)
-    if (secret == undefined) {
-      return res.status(500).json({ error: 'JWT secret not configured' });
-    }
-
-    const tokenResponse = jwt.verify(token, secret) as JwtPayload
+    const tokenResponse = jwt.verify(token, JWT_SECRET) as JwtPayload
 
     //attach userId to request
     req.userId = tokenResponse.userId

--- a/backend/src/services/__tests__/unit/login.service.test.ts
+++ b/backend/src/services/__tests__/unit/login.service.test.ts
@@ -35,7 +35,6 @@ describe('LoginService', () => {
         } as unknown as Mocked<LoginRepository>;
 
         loginService = new LoginService(mockLoginRepository);
-        process.env.JWT_SECRET = 'test-secret';
     });
 
     const date = new Date();
@@ -70,7 +69,7 @@ describe('LoginService', () => {
 
         expect(jwt.sign).toHaveBeenCalledWith(
             { userId: user.id },
-            'test-secret',
+            'test-only-fake-secret-value-1234',
             { expiresIn: '7d' }
         );
 

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -7,6 +7,7 @@ import { SafeUser } from '../types/auth.types'
 import { z } from 'zod';
 import jwt, { JwtPayload } from 'jsonwebtoken';
 import { AppError } from "../utils/errors";
+import { JWT_SECRET } from "../config/env";
 
 export class AuthService {
   constructor(private authRepository: AuthRepository) { }
@@ -47,12 +48,8 @@ export class AuthService {
   }
 
   async getUserByToken(token: string) {
-    const secret = String(process.env.JWT_SECRET)
-    if (secret == undefined) {
-      throw new AppError("JWT secret not configured", 500);
-    }
     try {
-      const tokenResponse = jwt.verify(token, secret) as JwtPayload
+      const tokenResponse = jwt.verify(token, JWT_SECRET) as JwtPayload
       const id = tokenResponse.userId
 
       const user = await this.authRepository.findById(id);

--- a/backend/src/services/login.service.ts
+++ b/backend/src/services/login.service.ts
@@ -6,6 +6,7 @@ import { LoginRepository } from '../repositories/login.repository';
 import { LoginDTO, LoginResponse } from "@civickit/shared";
 import "dotenv/config";
 import { AppError } from "../utils/errors";
+import { JWT_SECRET } from "../config/env";
 
 export class LoginService {
   constructor(private loginRepository: LoginRepository) { }
@@ -25,8 +26,7 @@ export class LoginService {
     }
 
     //generate token with user id
-    const key = String(process.env.JWT_SECRET)
-    const token = jwt.sign({ userId: user.id }, key, { expiresIn: '7d' })
+    const token = jwt.sign({ userId: user.id }, JWT_SECRET, { expiresIn: '7d' })
 
     const loginResponse: LoginResponse = {
       token: token,

--- a/backend/vitest.config.js
+++ b/backend/vitest.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     test: {
         include: ['**/*.test.ts'],
         // Run this file before every test file
-        //setupFiles: ['./src/__tests__/integration/setup.ts'],
+        setupFiles: ['./src/__tests__/setup-env.ts'],
         environment: 'node',
         globals: true,
     }


### PR DESCRIPTION
## Harden JWT secret handling (fail-closed, single validated source)

How to test
```
git checkout advisor/002-harden-jwt-secret
cd backend && npm install && npx prisma generate
npm run typecheck   # exit 0
npm test            # 6 files, 39 tests pass (main was 5/35; +4, none lost)
npm run build       # exit 0
```
Real behavior check (TypeScript can't catch this bug — String(x) == undefined is valid TS):
1. Comment out JWT_SECRET in backend/.env
2. `npm run dev` → must refuse to start:
3. Environment variable JWT_SECRET is missing or too short (min 16 chars). Refusing to start.
4. Restore it → starts, log in as normal.

Files added
- `backend/src/config/env.ts` — the fix. requireEnv(name, minLength) throws if missing/short; exports validated JWT_SECRET. Error messages name the variable, never its value.
- `backend/src/__tests__/setup-env.ts` — seeds a fake secret for tests (they run with no .env, and env.ts now throws at import time).
- `backend/src/config/__tests__/env.test.ts` — 4 unit tests for requireEnv.

Files modified:
- `auth.middleware.ts, auth.service.ts` — removed String() + dead guard; now jwt.verify(token, JWT_SECRET).
- `login.service.ts` — same; jwt.sign(..., JWT_SECRET, ...).
- `vitest.config.js` — enabled setupFiles → setup-env.ts (runs before test imports, the only hook early enough to seed the secret).
- `login.service.test.ts` — deleted a now-dead beforeEach env mutation; updated the by-value secret assertion. No coverage change.

### What the problem was

Three places in the backend read the JWT signing secret like this:

```ts
const secret = String(process.env.JWT_SECRET)
if (secret == undefined) {
  return res.status(500).json({ error: 'JWT secret not configured' });
}
```
These lines are code that does not work

String(undefined) does not return undefined, it returns the literal 9-character _string_ "undefined". So if the JWT_SECRET environment variable is ever missing, the secret silently becomes the word "undefined", and every login token gets signed with it. Anyone who guesses that string, can forge a valid token for any userId. That allows for full authentication bypass.

The guard on the next line was supposed to catch exactly this. It can't. By that point secret is the string "undefined", not the value undefined. Comparing them is always false, so the guard never fires. It's dead code that looks like protection.

The failure mode is the dangerous kind: the app keeps running and looks completely healthy. No crash, no log, no error. You'd find out when someone logged in as an admin.

This affected all three sites:
- token verification in `auth.middleware.ts`
- token signing in `login.service.ts`
- token verification in `auth.service.ts`

Nobody hit this in development because our local .env files have JWT_SECRET set. The bug only wakes up when the variable is missing, a fresh clone, a new deploy, a typo'd variable name in a hosting dashboard.

How it's fixed
A single config module (backend/src/config/env.ts) reads the secret once, at startup, and validates it:

Missing → throw, process refuses to start
Shorter than 16 characters → throw, process refuses to start
All three sites now import that validated value. No String() coercion, no dead guards.

The result is that there is no third state. Either the app has a real secret, or the app does not run. It can never again run while insecure.

Design decision: why "refuse to start" instead of "log a warning": a warning gets ignored; a server that won't boot gets fixed in five minutes. A loud bad deploy beats a quiet one. The whole value of this change is that a misconfiguration becomes impossible to ignore.

