### PR TITLE
Advisor/006 api hardening

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,3 +5,5 @@ CLOUDINARY_CLOUD_NAME="your-cloud-name"
 CLOUDINARY_API_KEY="your-api-key"
 CLOUDINARY_API_SECRET="your-api-secret"
 PORT=3000
+# Comma-separated list of browser origins allowed by CORS.
+ALLOWED_ORIGINS=http://localhost:3001

--- a/backend/src/__tests__/issue-validation.test.ts
+++ b/backend/src/__tests__/issue-validation.test.ts
@@ -1,0 +1,55 @@
+// backend/src/__tests__/issue-validation.test.ts
+import { describe, it, expect } from 'vitest';
+import { createIssueSchema } from '../schemas/issue.schema';
+
+const validBody = {
+  title: 'Pothole on Main St',
+  description: 'Large pothole causing traffic hazard',
+  category: 'road',
+  latitude: 38.6270,
+  longitude: -90.1994,
+  address: '123 Main St',
+  images: ['https://example.com/photo.jpg'],
+};
+
+describe('createIssueSchema', () => {
+  it('accepts a valid body', () => {
+    const result = createIssueSchema.safeParse(validBody);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a body missing title', () => {
+    const { title, ...rest } = validBody;
+    const result = createIssueSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a title under 3 characters', () => {
+    const result = createIssueSchema.safeParse({ ...validBody, title: 'ab' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects images containing a non-URL string', () => {
+    const result = createIssueSchema.safeParse({
+      ...validBody,
+      images: ['not-a-url'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an out-of-range latitude', () => {
+    const result = createIssueSchema.safeParse({ ...validBody, latitude: 200 });
+    expect(result.success).toBe(false);
+  });
+
+  it('strips unknown keys, preventing mass assignment', () => {
+    const result = createIssueSchema.safeParse({
+      ...validBody,
+      userId: 'attacker-supplied',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('userId');
+    }
+  });
+});

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -18,3 +18,9 @@ export function requireEnv(name: string, minLength = 1): string {
 
 // JWT secret must be present and reasonably long. Never log this value.
 export const JWT_SECRET = requireEnv('JWT_SECRET', 16);
+
+// Comma-separated list of allowed browser origins. Falls back to a localhost dev origin.
+export const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS ?? 'http://localhost:3001')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);

--- a/backend/src/middleware/validate.ts
+++ b/backend/src/middleware/validate.ts
@@ -1,0 +1,13 @@
+import { Request, Response, NextFunction } from 'express';
+import { ZodType } from 'zod';
+import { AppError } from '../utils/errors';
+
+export const validateBody = (schema: ZodType) =>
+  (req: Request, _res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.body);
+    if (!result.success) {
+      return next(new AppError('Invalid request body', 400));
+    }
+    req.body = result.data; // normalized + unknown keys stripped
+    next();
+  };

--- a/backend/src/routes/issue.routes.ts
+++ b/backend/src/routes/issue.routes.ts
@@ -5,13 +5,15 @@ import { UpvoteController } from '../controllers/upvote.controller';
 import { authMiddleware } from '../middleware/auth.middleware';
 import { requirePermission } from '../middleware/authorize.middleware';
 import { TimelineController } from '../controllers/timeline.controller';
+import { validateBody } from '../middleware/validate';
+import { createIssueSchema } from '../schemas/issue.schema';
 
 const router = Router();
 const issueController = new IssueController();
 const upvoteController = new UpvoteController();
 const timelineController = new TimelineController();
 
-router.post('/', authMiddleware, issueController.createIssue);
+router.post('/', authMiddleware, validateBody(createIssueSchema), issueController.createIssue);
 router.get('/nearby', issueController.getNearbyIssues);
 router.get('/user', issueController.getIssuesByUser);
 router.get('/userUpvotes', issueController.getIssuesByUserUpvotes);

--- a/backend/src/schemas/issue.schema.ts
+++ b/backend/src/schemas/issue.schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+export const createIssueSchema = z.object({
+  title: z.string().min(3).max(200),
+  description: z.string().max(5000).default(''),
+  category: z.string().min(1),
+  latitude: z.coerce.number().gte(-90).lte(90),
+  longitude: z.coerce.number().gte(-180).lte(180),
+  address: z.string().max(500).optional(),
+  district: z.string().max(200).optional(),
+  subregion: z.string().max(200).optional(),
+  name: z.string().max(200).optional(),
+  images: z.array(z.string().url()).max(10).default([]),
+  locationSource: z.string().max(50).optional(),
+  photoTakenAt: z.coerce.date().optional(),
+  photoTakenAtSource: z.string().max(50).optional(),
+}).strip();

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,24 +9,39 @@ import authRoutes from "./routes/auth.routes";
 import uploadRoutes from './routes/upload.routes';
 import loginRoutes from './routes/login.routes';
 import RateLimit from 'express-rate-limit';
-import { authMiddleware } from './middleware/auth.middleware';
 import { errorHandler } from './middleware/error.middleware';
 import { requestLogger } from './middleware/logger.middleware';
 import { toNodeHandler } from "better-auth/node";
 import { auth } from "./auth";
 import { isAPIError, } from "better-auth/api";
+import { ALLOWED_ORIGINS } from './config/env';
 
 dotenv.config();
 
 const app = express();
 const PORT = Number(process.env.PORT) || 3000;
 
+// Rate Limiter (general)
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, //15 minutes
+  max: 100, //max 100 requests per window
+})
+
+// Stricter limiter for the auth surface (sign-in/sign-up) to curb brute-force/enumeration.
+const authLimiter = RateLimit({
+  windowMs: 15 * 60 * 1000, //15 minutes
+  max: 20,
+})
+
 //BetterAuth
-app.all("/api/better-auth/auth/{*any}", toNodeHandler(auth));
+app.all("/api/better-auth/auth/{*any}", authLimiter, toNodeHandler(auth));
 
 // Middleware
-const corsOptions = {
-  origin: '*',
+const corsOptions: cors.CorsOptions = {
+  origin(origin, callback) {
+    if (!origin || ALLOWED_ORIGINS.includes(origin)) return callback(null, true);
+    return callback(new Error('Not allowed by CORS'));
+  },
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],
 };
@@ -41,11 +56,6 @@ app.get('/health', (req, res) => {
   res.json({ status: 'ok', timestamp: new Date().toISOString() });
 });
 
-// Rate Limiter
-const limiter = RateLimit({
-  windowMs: 15 * 60 * 1000, //15 minutes
-  max: 100, //max 100 requests per window
-})
 app.use(limiter)
 
 // Routes
@@ -54,7 +64,6 @@ app.use('/api/issues', issueRoutes);
 app.use('/api/auth/login', loginRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/upload', uploadRoutes);
-app.use('/api/issues/upvote', authMiddleware);
 
 // Error handling
 // 404 handler


### PR DESCRIPTION
## Description

Three gaps in the request pipeline, all config-level:

**CORS was `origin: '*'`** while allowing the `Authorization` header, any website could call the API from a victim's browser. Now driven by an `ALLOWED_ORIGINS` env allowlist. The check explicitly permits requests with no `Origin` header, because React Native sends none, dropping that branch would break the mobile app.

**The BetterAuth endpoints had no rate limiting.** The global limiter was registered *after* the BetterAuth handler, and Express runs middleware in registration order, so sign-in/sign-up bypassed it entirely — open to password brute-force. Added a stricter limiter (20/15min vs the general 100) applied directly to that mount.

**No schema validation on request bodies.** `POST /issues` spread `...req.body` straight through, so any client-supplied field was persisted. Added a zod schema that validates types/ranges and strips unknown keys.

Also deleted a dead `app.use('/api/issues/upvote', authMiddleware)` line that never ran.

## Files Added

- `backend/src/middleware/validate.ts` — a reusable `validateBody(schema)` Express middleware. Runs `safeParse`, returns a 400 `AppError` on failure, and replaces `req.body` with the parsed result so downstream code gets normalized, stripped data.
- `backend/src/schemas/issue.schema.ts` — `createIssueSchema`, the zod shape for issue creation. Bounds string lengths, constrains latitude/longitude to valid ranges, requires `images` entries to be URLs (max 10), and `.strip()`s unknown keys.
- `backend/src/__tests__/issue-validation.test.ts` — 6 schema tests: valid body, missing title, too-short title, non-URL image, out-of-range latitude, and unknown-key stripping (proves mass-assignment protection).

## Files Modified

- `backend/src/server.ts` — Express app setup. Replaced the wildcard `corsOptions` with an allowlist function; added `authLimiter` and applied it to the BetterAuth mount; moved the general limiter's definition above the routes; deleted the dead upvote-middleware line and its now-unused `authMiddleware` import.
- `backend/src/config/env.ts` — the validated env module. Appended an `ALLOWED_ORIGINS` export that parses a comma-separated list, defaulting to `http://localhost:3001`. `requireEnv`/`JWT_SECRET` untouched.
- `backend/src/routes/issue.routes.ts` — issue route table. Added `validateBody(createIssueSchema)` to `POST /` only. All other routes, including the `requirePermission` RBAC gates and timeline routes, are unchanged.
- `backend/.env.example` — env template. Added `ALLOWED_ORIGINS` with a comment.

## To Test

```bash
git checkout advisor/006-api-hardening
cd backend && npm install && npx prisma generate
npx tsc --noEmit -p tsconfig.json   # exit 0
npm test                            # 11 files, 66 tests pass (60 baseline + 6 new)
npm run build                       # exit 0
```
### Manual checks (needs Postgres running — npm run db:up — and migrations applied):

Mobile still works. Create an issue from the app end-to-end. It must succeed — this is the main regression risk, since the new schema now gates that endpoint.
Validation rejects bad input:
```
curl -i -X POST http://localhost:3000/api/issues \
  -H "Authorization: Bearer <token>" -H "Content-Type: application/json" \
  -d '{"title":"ab","category":"POTHOLE","latitude":38.6,"longitude":-90.2}'
```
Expect 400 (title under 3 chars). A valid body should still return 201.
Rate limiting: send >20 requests in 15 min to /api/better-auth/auth/* and confirm later ones get 429.
### Big Picture
CivicKit is heading for public deployment with real user accounts. These three gaps are the ones an auditor checks first: an open CORS policy, an unthrottled login endpoint, and an API that trusts whatever JSON a client sends. Closing them turns "works on localhost" into something that can face the internet. The validate.ts + schemas/ pattern is also reusable — future mutation endpoints get validation by adding one middleware instead of hand-rolling checks in each controller.

### Tech Notes
- Express middleware order is the security boundary. A rate limiter registered after a route handler never protects it. Register limiters before the mounts they guard.
z.string().optional() accepts undefined, not null. The mobile app currently sends undefined for missing metadata (useResolvedAddress.ts does value || undefined), so this works — but if a helper ever starts returning null, issue creation will 400. Use .nullish() if null becomes a real case.
.strip() is the mass-assignment defense. Unknown keys are dropped rather than passed to Prisma, so a client can't set fields it shouldn't.
- CORS must allow empty Origin. Native mobile apps send no Origin header; a strict allowlist without that branch blocks them.