### PR TITLE
mobile: exit auth loading state when no stored token exists

### DIFF
--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -29,6 +29,9 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         (async () => {
             const token = await getToken();
             setAuthToken(token);
+            if (token == null) {
+                setIsLoading(false); //no stored token: skip user fetch, go to login
+            }
         })();
     }, []); //no dependencies bc it runs once on mount to check for token
 


### PR DESCRIPTION
## Problem

On a fresh install (no previously stored auth token), the app hangs on the loading screen forever and never reaches the login screen.

**Root cause:** `AuthContext` reads the token from secure storage on mount, then fetches the user via a TanStack Query gated on `enabled: !!authToken`. The `isLoading` flag is only cleared when that query yields data or an error — but with no stored token the query never runs, so `isLoading` stays `true` indefinitely and `AppNavigator` renders `<LoadingScreen />` forever.

This goes unnoticed on dev devices because they have a token persisted from earlier builds; only a truly fresh install (or cleared storage) hits it.

## Fix

Clear `isLoading` immediately when the mount-time token read returns null: with no token there is no user to fetch, and the correct state is "not logged in, not loading." The existing flow for stored tokens is unchanged.

## Testing

Reproduced on a fresh simulator install (stuck on loading screen, zero requests hitting the backend). With this change the app lands on the login screen and login with a seeded user works normally.