### PR TITLE
Advisor/007 issue list perf

### DIFF
--- a/backend/src/controllers/issue.controller.ts
+++ b/backend/src/controllers/issue.controller.ts
@@ -8,6 +8,24 @@ const issueRepository = new IssueRepository();
 const upvoteRepository = new UpvoteRepository();
 const issueService = new IssueService(issueRepository, upvoteRepository);
 
+// Parses an optional `limit` query param, clamped to [1, 200], defaulting to 100.
+function parseLimit(raw: unknown): number {
+  const DEFAULT_LIMIT = 100;
+  const MIN_LIMIT = 1;
+  const MAX_LIMIT = 200;
+
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return DEFAULT_LIMIT;
+  }
+
+  const parsed = parseInt(raw, 10);
+  if (isNaN(parsed)) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(MAX_LIMIT, Math.max(MIN_LIMIT, parsed));
+}
+
 export class IssueController {
   async createIssue(req: Request, res: Response, next: NextFunction) {
     try {
@@ -35,12 +53,13 @@ export class IssueController {
       const lat = parseFloat(req.query.lat as string);
       const lng = parseFloat(req.query.lng as string);
       const radius = req.query.radius ? parseInt(req.query.radius as string) : undefined;
+      const limit = parseLimit(req.query.limit);
 
       if (isNaN(lat) || isNaN(lng)) {
         return res.status(400).json({ error: 'Invalid coordinates' });
       }
 
-      const issues = await issueService.getNearbyIssues(lat, lng, radius);
+      const issues = await issueService.getNearbyIssues(lat, lng, radius, limit);
       res.json({ issues });
     } catch (error) {
       next(error);
@@ -58,7 +77,8 @@ export class IssueController {
 
   async getIssuesByUser(req: Request, res: Response, next: NextFunction) {
     try {
-      const issues = await issueService.getIssuesByUser(String(req.query.id));
+      const limit = parseLimit(req.query.limit);
+      const issues = await issueService.getIssuesByUser(String(req.query.id), limit);
       res.json({ issues });
     } catch (error) {
       next(error);
@@ -67,7 +87,8 @@ export class IssueController {
 
   async getIssuesByUserUpvotes(req: Request, res: Response, next: NextFunction) {
     try {
-      const issues = await issueService.getIssuesByUserUpvotes(String(req.query.id));
+      const limit = parseLimit(req.query.limit);
+      const issues = await issueService.getIssuesByUserUpvotes(String(req.query.id), limit);
       res.json({ issues });
     } catch (error) {
       next(error);

--- a/backend/src/repositories/issue.repository.ts
+++ b/backend/src/repositories/issue.repository.ts
@@ -39,11 +39,13 @@ export class IssueRepository {
     });
   }
 
-  async findNearby(lat: number, lng: number, radiusMeters: number = 1000): Promise<Issue[]> {
+  // TODO(integration): assert LIMIT + upvoteCount against a real PostGIS database
+  async findNearby(lat: number, lng: number, radiusMeters: number = 1000, limit: number = 100): Promise<any[]> {
     // Using raw SQL for PostGIS geospatial query
     return prisma.$queryRaw`
-      SELECT 
+      SELECT
         i.*,
+        (SELECT count(*)::int FROM "Upvote" u WHERE u."issueId" = i.id) AS "upvoteCount",
         ST_Distance(
           ST_SetSRID(ST_MakePoint(i.longitude, i.latitude), 4326)::geography,
           ST_SetSRID(ST_MakePoint(${lng}, ${lat}), 4326)::geography
@@ -55,6 +57,7 @@ export class IssueRepository {
         ${radiusMeters}
       )
       ORDER BY distance ASC
+      LIMIT ${limit}
     `;
   }
 
@@ -78,7 +81,7 @@ export class IssueRepository {
     });
   }
 
-  async findByUser(id: string) {
+  async findByUser(id: string, limit: number = 100) {
     return prisma.issue.findMany({
       where: { userId: id },
       include: {
@@ -95,6 +98,19 @@ export class IssueRepository {
           },
         },
       },
+      take: limit,
+    });
+  }
+
+  async findByUpvoter(userId: string, limit: number = 100) {
+    return prisma.issue.findMany({
+      where: { upvotes: { some: { userId } } },
+      include: {
+        user: { select: { id: true, name: true, profileImage: true } },
+        _count: { select: { upvotes: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
     });
   }
 

--- a/backend/src/services/__tests__/unit/issue.service.test.ts
+++ b/backend/src/services/__tests__/unit/issue.service.test.ts
@@ -26,6 +26,8 @@ describe('IssueService', () => {
       create: vi.fn(),
       findById: vi.fn(),
       findNearby: vi.fn(),
+      findByUser: vi.fn(),
+      findByUpvoter: vi.fn(),
     } as unknown as Mocked<IssueRepository>;
 
     mockUpvoteRepository = {
@@ -217,6 +219,86 @@ describe('IssueService', () => {
       await expect(
         issueService.getIssueById('123')
       ).rejects.toThrow('Issue not found');
+    });
+  });
+
+  describe('getNearbyIssues', () => {
+    it('should return issues from the repository without an N+1 upvote count loop', async () => {
+      const mockIssues = [
+        { id: 'issue-1', upvoteCount: 3 },
+        { id: 'issue-2', upvoteCount: 0 },
+      ];
+      mockIssueRepository.findNearby.mockResolvedValue(mockIssues as any);
+
+      const result = await issueService.getNearbyIssues(38.627, -90.1994);
+
+      expect(mockUpvoteRepository.countUpvotes).not.toHaveBeenCalled();
+      expect(mockIssueRepository.findNearby).toHaveBeenCalledWith(
+        38.627,
+        -90.1994,
+        undefined,
+        undefined
+      );
+      expect(result).toEqual(mockIssues);
+      result.forEach((issue) => {
+        expect(typeof issue.upvoteCount).toBe('number');
+      });
+    });
+
+    it('should pass radius and limit through to the repository', async () => {
+      mockIssueRepository.findNearby.mockResolvedValue([]);
+
+      await issueService.getNearbyIssues(38.627, -90.1994, 500, 50);
+
+      expect(mockIssueRepository.findNearby).toHaveBeenCalledWith(
+        38.627,
+        -90.1994,
+        500,
+        50
+      );
+    });
+  });
+
+  describe('getIssuesByUser', () => {
+    it('should not call countUpvotes and should map _count.upvotes onto upvoteCount', async () => {
+      const mockIssues = [
+        { id: 'issue-1', _count: { upvotes: 5 } },
+        { id: 'issue-2', _count: { upvotes: 0 } },
+      ];
+      mockIssueRepository.findByUser.mockResolvedValue(mockIssues as any);
+
+      const result = await issueService.getIssuesByUser('user-123');
+
+      expect(mockUpvoteRepository.countUpvotes).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        { id: 'issue-1', _count: { upvotes: 5 }, upvoteCount: 5 },
+        { id: 'issue-2', _count: { upvotes: 0 }, upvoteCount: 0 },
+      ]);
+      result.forEach((issue) => {
+        expect(typeof issue.upvoteCount).toBe('number');
+      });
+    });
+  });
+
+  describe('getIssuesByUserUpvotes', () => {
+    it('should call findByUpvoter exactly once and never call findById', async () => {
+      const mockIssues = [
+        { id: 'issue-1', _count: { upvotes: 2 } },
+      ];
+      mockIssueRepository.findByUpvoter.mockResolvedValue(mockIssues as any);
+
+      const result = await issueService.getIssuesByUserUpvotes('user-123');
+
+      expect(mockIssueRepository.findByUpvoter).toHaveBeenCalledTimes(1);
+      expect(mockIssueRepository.findByUpvoter).toHaveBeenCalledWith('user-123', undefined);
+      expect(mockIssueRepository.findById).not.toHaveBeenCalled();
+      expect(mockUpvoteRepository.countUpvotes).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        { id: 'issue-1', _count: { upvotes: 2 }, upvoteCount: 2 },
+      ]);
+      result.forEach((issue) => {
+        expect(typeof issue.upvoteCount).toBe('number');
+      });
     });
   });
 });

--- a/backend/src/services/issue.service.ts
+++ b/backend/src/services/issue.service.ts
@@ -26,22 +26,8 @@ export class IssueService {
     return this.issueRepository.create({ ...data, userId, status: 'REPORTED' });
   }
 
-  async getNearbyIssues(lat: number, lng: number, radius?: number) {
-    const issues = await this.issueRepository.findNearby(lat, lng, radius);
-
-    const issuesWithUpvoteCounts = await Promise.all(
-      issues.map(async (issue) => {
-
-        const upvoteCount = await this.upvoteRepository.countUpvotes(issue.id);
-
-        return {
-          ...issue,
-          upvoteCount,
-        };
-
-      })
-    );
-    return issuesWithUpvoteCounts;
+  async getNearbyIssues(lat: number, lng: number, radius?: number, limit?: number) {
+    return this.issueRepository.findNearby(lat, lng, radius, limit);
   }
 
   async getIssueById(id: string) {
@@ -58,43 +44,16 @@ export class IssueService {
     };
   }
 
-  async getIssuesByUser(id: string) {
-    const issues = await this.issueRepository.findByUser(id);
+  async getIssuesByUser(id: string, limit?: number) {
+    const issues = await this.issueRepository.findByUser(id, limit);
 
-    const issuesWithUpvoteCounts = await Promise.all(
-      issues.map(async (issue) => {
-
-        const upvoteCount = await this.upvoteRepository.countUpvotes(issue.id);
-
-        return {
-          ...issue,
-          upvoteCount,
-        };
-
-      })
-    );
-
-    return issuesWithUpvoteCounts;
+    return issues.map((issue) => ({ ...issue, upvoteCount: issue._count.upvotes }));
   }
 
-  async getIssuesByUserUpvotes(id: string) {
-    const upvotes = await this.upvoteRepository.findByUser(id);
-    const issues = await Promise.all(upvotes.map(async (upvote) => { return this.issueRepository.findById(upvote.issueId) }))
-    const issuesWithUpvoteCounts = await Promise.all(
-      issues.map(async (issue) => {
+  async getIssuesByUserUpvotes(id: string, limit?: number) {
+    const issues = await this.issueRepository.findByUpvoter(id, limit);
 
-        const upvoteCount = await this.upvoteRepository.countUpvotes(issue!.id);
-
-        return {
-          ...issue,
-          upvoteCount,
-        };
-
-      })
-    );
-
-    return issuesWithUpvoteCounts;
-
+    return issues.map((issue) => ({ ...issue, upvoteCount: issue._count.upvotes }));
   }
 
   // update status tag


### PR DESCRIPTION
## Description

Every issue-list endpoint counted upvotes with **one database query per issue**, inside a `Promise.all(map(...))`. A map view returning 50 issues fired 51 queries. None of the endpoints capped their result set either, so a dense area returned every issue in radius.

`getIssuesByUserUpvotes` was the worst: it re-fetched each upvoted issue individually, then counted upvotes on each — roughly 2N+1 round trips for a list that renders neither.

Now the counts come from the database in the same query. `findNearby` uses a correlated subquery in its PostGIS SQL; the Prisma paths use the `_count` aggregate they already selected. All three list methods dropped their loops.

Design note: the response shape is unchanged on purpose. The mobile app reads a flat `issue.upvoteCount` in six places (`IssueCard`, `IssueDetailScreen`, `LeaderboardScreen`, `StatsScreen` — the last two *sort* on it), so the services still emit exactly that field. This is a pure backend optimization with no client changes required.

## Files Modified

- `backend/src/repositories/issue.repository.ts` — data access for issues. `findNearby` now selects `(SELECT count(*)::int ...) AS "upvoteCount"` and takes a `LIMIT` (default 100). `findByUser` gained `take`. Added `findByUpvoter(userId, limit)`, which fetches upvoted issues in one query via an `upvotes: { some: { userId } }` relation filter.
- `backend/src/services/issue.service.ts` — issue business logic. `getNearbyIssues` is now a passthrough (the count arrives in the row). `getIssuesByUser` maps `_count.upvotes` to `upvoteCount` in a single synchronous `.map`. `getIssuesByUserUpvotes` calls `findByUpvoter` once instead of looping `findById`. `createIssue`, `getIssueById`, and `updateStatus` are untouched.
- `backend/src/controllers/issue.controller.ts` — issue route handlers. The three list endpoints accept an optional `limit` query param, parsed and clamped to 1–200, defaulting to 100. Omitting it preserves existing behavior (now capped).
- `backend/src/services/__tests__/unit/issue.service.test.ts` — service unit tests. Added 4 cases asserting `countUpvotes` is never called, `findById` is never called per-upvote, `findByUpvoter` is called exactly once, and every returned item still exposes a numeric `upvoteCount`.

## To Test

```bash
git checkout advisor/007-issue-list-perf
cd backend && npm install && npx prisma generate
npx tsc --noEmit -p tsconfig.json   # exit 0
npm test                            # 11 files, 70 tests pass (66 baseline + 4 new)
npm run build                       # exit 0