### PR TITLE
feat(backend): validate name on registration (closes #165)

### DIFF
--- a/backend/src/services/__tests__/unit/auth.service.test.ts
+++ b/backend/src/services/__tests__/unit/auth.service.test.ts
@@ -88,6 +88,57 @@ describe('AuthService', () => {
             new AppError('Password too short (min 8 characters)', 400));
     });
 
+    it.each([
+        ['an empty name', ''],
+        ['a whitespace-only name', '   '],
+        ['a single-character name', 'A'],
+    ])('should throw a 400 for %s', async (_label, name) => {
+        await expect(
+            authService.registerUser({
+                email: 'test@example.com',
+                password: 'password123',
+                name,
+            })
+        ).rejects.toEqual(new AppError('Name is required (min 2 characters)', 400));
+    });
+
+    it('should throw a 400 for a name longer than 100 characters', async () => {
+        await expect(
+            authService.registerUser({
+                email: 'test@example.com',
+                password: 'password123',
+                name: 'a'.repeat(101),
+            })
+        ).rejects.toEqual(new AppError('Name too long (max 100 characters)', 400));
+    });
+
+    it('should trim the name before persisting it', async () => {
+        mockAuthRepository.findByEmail.mockResolvedValue(null);
+        (bcrypt.hash as any).mockResolvedValue('hashedPassword');
+        mockAuthRepository.createUser.mockResolvedValue({
+            id: '1',
+            email: 'test@example.com',
+            name: 'Jane Doe',
+            passwordHash: 'hashedPassword',
+            profileImage: null,
+            role: 'REPORTER',
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            emailVerified: false,
+            image: null,
+        });
+
+        await authService.registerUser({
+            email: 'test@example.com',
+            password: 'password123',
+            name: '  Jane Doe  ',
+        });
+
+        expect(mockAuthRepository.createUser).toHaveBeenCalledWith(
+            expect.objectContaining({ name: 'Jane Doe' })
+        );
+    });
+
     it('should throw error if email already exists', async () => {
         mockAuthRepository.findByEmail.mockResolvedValue({
             id: '1',

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -24,6 +24,15 @@ export class AuthService {
       throw new AppError("Password too short (min 8 characters)", 400);
     }
 
+    // Validate name: trim, reject empty/whitespace-only, bound the length.
+    const trimmedName = typeof name === "string" ? name.trim() : "";
+    if (trimmedName.length < 2) {
+      throw new AppError("Name is required (min 2 characters)", 400);
+    }
+    if (trimmedName.length > 100) {
+      throw new AppError("Name too long (max 100 characters)", 400);
+    }
+
     // Check for existing user
     const existingUser = await this.authRepository.findByEmail(email);
     if (existingUser) {
@@ -33,10 +42,11 @@ export class AuthService {
     // Hash password
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    // Create user in database
+    // Create user in database (store the trimmed name so stray whitespace never
+    // persists).
     const newUser = await this.authRepository.createUser({
       email,
-      name,
+      name: trimmedName,
       passwordHash: hashedPassword,
     });
 


### PR DESCRIPTION
## What & why

Closes #165 — "No checks on if someone puts in their full name."

`AuthService.registerUser` validated email and password but did **nothing** with `name`: an empty or whitespace-only string was accepted and written to the database. This adds server-side validation in the same style as the existing guards.

## Change

In `registerUser` (before the DB write):
- **trim** the name
- reject empty / whitespace-only / `< 2` chars → **400** `"Name is required (min 2 characters)"`
- reject `> 100` chars → **400** `"Name too long (max 100 characters)"`
- persist the **trimmed** value so stray whitespace never reaches the DB

## Scope decision

Kept the single `name` field. The issue floated splitting into first/last as a "maybe" — that's a schema migration + mobile change, so I left it as a separate decision rather than assume it here.

## Testing

- `npm run typecheck` — clean
- `npx vitest run` — **75/75** pass (5 new cases: empty, whitespace-only, 1-char, >100-char all 400; and a test asserting the stored name is trimmed)

Server-side validation is the real fix — the mobile client already trims client-side, but that's bypassable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
