### PR TITLE
mobile: route all backend calls through a typed API client

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -69,7 +69,7 @@ curl -X POST http://localhost:3000/api/issues \
 ```
 
 ## Mobile Setup
-The app reads the backend address from `mobile/src/config/env.local.json`. This file is gitignored — it is generated for you by the start scripts below, so always use them the first time.
+The app derives the backend address from the Metro host it was loaded from, so testing on a physical phone needs no configuration — your machine's LAN IP is discovered automatically. To point at something else, set `EXPO_PUBLIC_API_URL` (see the Cloudflare proxy steps below).
 
 1. From the `mobile/` directory
 ```bash
@@ -78,14 +78,14 @@ npm install
 ```
 2. In the `mobile/` directory, choose `startWin.sh` for Windows or `startMac.sh` for Mac
    1. In a bash terminal, set permissions with `chmod +x startWin.sh` or `chmod +x startMac.sh` (You only need to do this once)
-   2. To start using your IPv4 address as the domain (necessary to test on a physical phone), run `./startWin.sh ip` or `./startMac.sh ip`
+   2. Run `./startWin.sh` or `./startMac.sh` — this uses your LAN address and works on a physical phone
    3. To start on localhost (fine for simulators/emulators), run `./startWin.sh localhost` or `./startMac.sh localhost`
 
 * Press `i` to open iOS simulator (macOS only)
 * Press `a` to open Android emulator
 * Press `w` to run in the browser (web)
 
-To run on a physical device: start with the `ip` option (phone and computer must be on the same Wi-Fi network), then scan the QR code using the Camera app (iOS) or Expo Go (Android). Expo Go must be installed on the device. From Windows you may need production mode:
+To run on a physical device: start with no argument (phone and computer must be on the same Wi-Fi network), then scan the QR code using the Camera app (iOS) or Expo Go (Android). Expo Go must be installed on the device. From Windows you may need production mode:
 ```bash
 npx expo start --no-dev --minify
 ```
@@ -93,8 +93,12 @@ npx expo start --no-dev --minify
 If the app loads but fails to fetch (common on networks that block device-to-device traffic), proxy the backend through Cloudflare:
 1. ensure dependencies are up to date in backend `npm install`
 2. in `backend/` run `npm run dev`
-3. in `backend/` run `npm run dev:proxy` which generates a public trycloudflare.com link. Put that link (with `/api` appended) as the dev `apiUrl` in `mobile/src/config/env.ts`
-4. in `mobile/` run `npx expo start --tunnel`
+3. in `backend/` run `npm run dev:proxy` which generates a public trycloudflare.com link
+4. in `mobile/` run it with that link (with `/api` appended) as the API base URL:
+```bash
+EXPO_PUBLIC_API_URL=https://<your-link>.trycloudflare.com/api npx expo start --tunnel
+```
+Any `EXPO_PUBLIC_*` variable can also live in a `mobile/.env` file instead of the command line.
 
 ## Web Setup
 ```bash

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,0 +1,10 @@
+# Copy to mobile/.env only if you need to override the default.
+#
+# In development the API base URL is derived from the Metro host automatically,
+# so this file is usually unnecessary. Set it when pointing the app at a tunnel,
+# a staging environment, or a deployed backend. Required for release builds.
+#
+# EXPO_PUBLIC_API_URL=https://example.trycloudflare.com/api
+
+# Port used when deriving the dev URL from the Metro host. Defaults to 3000.
+# EXPO_PUBLIC_API_PORT=3000

--- a/mobile/.gitignore
+++ b/mobile/.gitignore
@@ -39,6 +39,3 @@ yarn-error.*
 # generated native folders
 /ios
 /android
-
-#local mobile env
-env.local.json

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,6 +1,7 @@
 // mobile/App.tsx
 import { NavigationContainer } from '@react-navigation/native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ApiError } from './src/api';
 import { AuthProvider, useAuth } from './src/contexts/AuthContext';
 import { MessageView } from './src/components/MessageView';
 import { StackParams } from './src/types/StackParams';
@@ -28,7 +29,19 @@ import LoadingScreen from './src/screens/Misc/LoadingScreen';
 
 const Tab = createBottomTabNavigator<TabParams>();
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // A 4xx will not become a 2xx on retry — only retry transport failures.
+      retry: (failureCount, error) => {
+        if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+          return false;
+        }
+        return failureCount < 2;
+      },
+    },
+  },
+});
 
 const Stack = createNativeStackNavigator<StackParams>();
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -61,7 +61,8 @@
         "@types/react": "~19.1.0",
         "@types/react-native-keyboard-spacer": "^0.4.6",
         "react-native-svg-transformer": "^1.5.3",
-        "typescript": "~5.9.2"
+        "typescript": "~5.9.2",
+        "vitest": "^4.1.10"
       }
     },
     "../shared": {
@@ -1628,6 +1629,40 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@expo/code-signing-certificates": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@expo/code-signing-certificates/-/code-signing-certificates-0.0.6.tgz",
@@ -2265,6 +2300,35 @@
         "xyz": "bin/xyz.js"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@react-leaflet/core": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
@@ -2818,6 +2882,288 @@
         "react-native-screens": ">= 4.0.0"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2841,6 +3187,13 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -3115,6 +3468,17 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -3155,6 +3519,31 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
@@ -3299,6 +3688,119 @@
       },
       "peerDependencies": {
         "@urql/core": "^5.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@xmldom/xmldom": {
@@ -3449,6 +3951,16 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
@@ -3925,6 +4437,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4682,6 +5204,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4749,6 +5278,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -4765,6 +5304,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/expo": {
@@ -6785,6 +7334,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -7226,9 +7785,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -7371,6 +7930,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -7718,6 +8291,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -8713,6 +9293,40 @@
         "node": "*"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -8916,6 +9530,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -9050,6 +9671,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -9076,6 +9704,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-buffers": {
       "version": "2.2.0",
@@ -9428,6 +10063,23 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -9471,6 +10123,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmpl": {
@@ -9738,6 +10400,229 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/vlq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
@@ -9826,6 +10711,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wonka": {

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -26,6 +26,7 @@
         "expo-asset": "~12.0.13",
         "expo-camera": "~17.0.10",
         "expo-checkbox": "~5.0.8",
+        "expo-constants": "~18.0.13",
         "expo-font": "~14.0.12",
         "expo-image": "~3.0.11",
         "expo-image-picker": "~17.0.11",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -6,7 +6,8 @@
     "start": "expo start",
     "android": "expo run:android",
     "ios": "expo run:ios",
-    "web": "expo start --web"
+    "web": "expo start --web",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@civickit/shared": "file:../shared",
@@ -27,6 +28,7 @@
     "expo-asset": "~12.0.13",
     "expo-camera": "~17.0.10",
     "expo-checkbox": "~5.0.8",
+    "expo-constants": "~18.0.13",
     "expo-font": "~14.0.12",
     "expo-image": "~3.0.11",
     "expo-image-picker": "~17.0.11",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -7,7 +7,9 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@civickit/shared": "file:../shared",
@@ -63,7 +65,8 @@
     "@types/react": "~19.1.0",
     "@types/react-native-keyboard-spacer": "^0.4.6",
     "react-native-svg-transformer": "^1.5.3",
-    "typescript": "~5.9.2"
+    "typescript": "~5.9.2",
+    "vitest": "^4.1.10"
   },
   "private": true
 }

--- a/mobile/src/api/__tests__/client.test.ts
+++ b/mobile/src/api/__tests__/client.test.ts
@@ -1,0 +1,271 @@
+// mobile/src/api/__tests__/client.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, NetworkError, apiFetch, setUnauthorizedHandler } from '../client';
+
+const BASE_URL = 'http://10.0.0.5:3000/api';
+
+vi.mock('../../config/env', () => ({
+    getApiBaseUrl: () => BASE_URL,
+}));
+
+const { getToken } = vi.hoisted(() => ({ getToken: vi.fn() }));
+vi.mock('../../services/tokenStorage', () => ({ getToken }));
+
+/** Builds a Response-alike; `fetch` is mocked, so only what apiFetch reads matters. */
+function jsonResponse(body: unknown, status = 200): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => (body === undefined ? '' : JSON.stringify(body)),
+    } as Response;
+}
+
+function textResponse(text: string, status: number): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => text,
+    } as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    vi.stubGlobal('fetch', fetchMock);
+    getToken.mockReset();
+    getToken.mockResolvedValue('stored-token');
+    setUnauthorizedHandler(null);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+});
+
+/** Awaits a rejection and hands back the thrown value, failing if it resolves. */
+async function rejection(promise: Promise<unknown>): Promise<any> {
+    try {
+        await promise;
+    } catch (error) {
+        return error;
+    }
+    throw new Error('Expected the request to reject, but it resolved');
+}
+
+/** The (url, init) pair the single fetch call received. */
+function lastCall(): [string, RequestInit] {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    return fetchMock.mock.calls[0] as [string, RequestInit];
+}
+
+describe('url construction', () => {
+    it('joins the base URL with a path that has no leading slash', async () => {
+        await apiFetch('issues/nearby');
+        expect(lastCall()[0]).toBe(`${BASE_URL}/issues/nearby`);
+    });
+
+    it('does not double the slash when the path has one', async () => {
+        await apiFetch('/issues/nearby');
+        expect(lastCall()[0]).toBe(`${BASE_URL}/issues/nearby`);
+    });
+
+    it('encodes query values', async () => {
+        await apiFetch('/issues/user', { query: { id: 'a b&c' } });
+        expect(lastCall()[0]).toBe(`${BASE_URL}/issues/user?id=a%20b%26c`);
+    });
+
+    it('omits undefined, null, and empty query params', async () => {
+        await apiFetch('/issues/nearby', {
+            query: { lat: 38.6, limit: undefined, radius: null, q: '' },
+        });
+        expect(lastCall()[0]).toBe(`${BASE_URL}/issues/nearby?lat=38.6`);
+    });
+
+    it('keeps a zero-valued query param', async () => {
+        await apiFetch('/issues/nearby', { query: { lat: 0 } });
+        expect(lastCall()[0]).toBe(`${BASE_URL}/issues/nearby?lat=0`);
+    });
+
+    it('appends no question mark when every param is dropped', async () => {
+        await apiFetch('/issues/nearby', { query: { limit: undefined } });
+        expect(lastCall()[0]).toBe(`${BASE_URL}/issues/nearby`);
+    });
+});
+
+describe('request shape', () => {
+    it('sends no body or Content-Type for a plain GET', async () => {
+        await apiFetch('/issues/nearby');
+        const [, init] = lastCall();
+        expect(init.method).toBe('GET');
+        expect(init.body).toBeUndefined();
+        expect(init.headers).not.toHaveProperty('Content-Type');
+    });
+
+    it('serializes a body as JSON and sets Content-Type', async () => {
+        await apiFetch('/issues/', { method: 'POST', body: { title: 'Pothole' } });
+        const [, init] = lastCall();
+        expect(init.method).toBe('POST');
+        expect(init.body).toBe('{"title":"Pothole"}');
+        expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    });
+});
+
+describe('auth', () => {
+    it('does not read stored credentials for unauthenticated calls', async () => {
+        await apiFetch('/issues/nearby');
+        expect(getToken).not.toHaveBeenCalled();
+        expect(lastCall()[1].headers).not.toHaveProperty('Authorization');
+    });
+
+    it('attaches the stored token when auth is requested', async () => {
+        await apiFetch('/issues/', { auth: true });
+        expect(lastCall()[1].headers).toMatchObject({ Authorization: 'Bearer stored-token' });
+    });
+
+    it('prefers an explicitly passed token over storage', async () => {
+        await apiFetch('/auth/user', { auth: true, token: 'explicit-token' });
+        expect(getToken).not.toHaveBeenCalled();
+        expect(lastCall()[1].headers).toMatchObject({ Authorization: 'Bearer explicit-token' });
+    });
+
+    it('fails without issuing a request when no token exists', async () => {
+        getToken.mockResolvedValue(null);
+        await expect(apiFetch('/issues/', { auth: true })).rejects.toMatchObject({
+            name: 'ApiError',
+            status: 401,
+        });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('does not log the user out over a locally missing token', async () => {
+        // Only the server gets to invalidate a session; firing here would risk a
+        // logout loop during startup, before the token has been read.
+        const onUnauthorized = vi.fn();
+        setUnauthorizedHandler(onUnauthorized);
+        getToken.mockResolvedValue(null);
+
+        await expect(apiFetch('/issues/', { auth: true })).rejects.toBeInstanceOf(ApiError);
+        expect(onUnauthorized).not.toHaveBeenCalled();
+    });
+});
+
+describe('error responses', () => {
+    it("reads the global error handler's { success, message } shape", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({ success: false, message: 'Issue not found' }, 404));
+        await expect(apiFetch('/issues/x')).rejects.toMatchObject({
+            message: 'Issue not found',
+            status: 404,
+        });
+    });
+
+    it("reads the auth middleware's { error } shape", async () => {
+        fetchMock.mockResolvedValue(jsonResponse({ error: 'Invalid or expired token' }, 401));
+        await expect(apiFetch('/issues/')).rejects.toMatchObject({
+            message: 'Invalid or expired token',
+        });
+    });
+
+    it('falls back to a non-JSON body', async () => {
+        fetchMock.mockResolvedValue(textResponse('Bad Gateway', 502));
+        await expect(apiFetch('/issues/')).rejects.toMatchObject({ message: 'Bad Gateway' });
+    });
+
+    it('falls back to the status when the body is empty', async () => {
+        fetchMock.mockResolvedValue(textResponse('', 500));
+        await expect(apiFetch('/issues/')).rejects.toMatchObject({
+            message: 'Request failed with status 500',
+        });
+    });
+
+    it('exposes the parsed body for callers that need detail', async () => {
+        fetchMock.mockResolvedValue(jsonResponse({ message: 'Nope', errors: ['title'] }, 400));
+        const error = await rejection(apiFetch('/issues/'));
+        expect(error).toBeInstanceOf(ApiError);
+        expect(error.body).toEqual({ message: 'Nope', errors: ['title'] });
+    });
+});
+
+describe('unauthorized handling', () => {
+    it('notifies the handler on a server 401', async () => {
+        const onUnauthorized = vi.fn();
+        setUnauthorizedHandler(onUnauthorized);
+        fetchMock.mockResolvedValue(jsonResponse({ error: 'Invalid or expired token' }, 401));
+
+        await expect(apiFetch('/issues/')).rejects.toBeInstanceOf(ApiError);
+        expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves the session alone for other failures', async () => {
+        const onUnauthorized = vi.fn();
+        setUnauthorizedHandler(onUnauthorized);
+
+        for (const status of [400, 403, 404, 500]) {
+            fetchMock.mockResolvedValue(jsonResponse({ message: 'nope' }, status));
+            await expect(apiFetch('/issues/')).rejects.toBeInstanceOf(ApiError);
+        }
+        expect(onUnauthorized).not.toHaveBeenCalled();
+    });
+
+    it('stops notifying once the handler is cleared', async () => {
+        const onUnauthorized = vi.fn();
+        setUnauthorizedHandler(onUnauthorized);
+        setUnauthorizedHandler(null);
+        fetchMock.mockResolvedValue(jsonResponse({ error: 'nope' }, 401));
+
+        await expect(apiFetch('/issues/')).rejects.toBeInstanceOf(ApiError);
+        expect(onUnauthorized).not.toHaveBeenCalled();
+    });
+});
+
+describe('transport failures', () => {
+    it('reports an unreachable server as a NetworkError', async () => {
+        fetchMock.mockRejectedValue(new TypeError('Network request failed'));
+        const error = await rejection(apiFetch('/issues/'));
+        expect(error).toBeInstanceOf(NetworkError);
+        expect(error.message).toMatch(/could not reach the server/i);
+    });
+
+    it('reports a timeout distinctly from an unreachable server', async () => {
+        fetchMock.mockImplementation(
+            (_url: string, init: RequestInit) =>
+                new Promise((_resolve, reject) => {
+                    init.signal?.addEventListener('abort', () => reject(new Error('Aborted')));
+                }),
+        );
+
+        const error = await rejection(apiFetch('/issues/', { timeoutMs: 50 }));
+        expect(error).toBeInstanceOf(NetworkError);
+        expect(error.message).toMatch(/timed out/i);
+    });
+
+    it('propagates a caller-initiated abort so React Query treats it as a cancellation', async () => {
+        const controller = new AbortController();
+        fetchMock.mockImplementation(
+            (_url: string, init: RequestInit) =>
+                new Promise((_resolve, reject) => {
+                    init.signal?.addEventListener('abort', () => reject(new Error('Aborted')));
+                }),
+        );
+
+        const promise = rejection(apiFetch('/issues/', { signal: controller.signal }));
+        controller.abort();
+        const error = await promise;
+
+        // Must not be reshaped into a NetworkError — a cancelled query is not a failure.
+        expect(error).not.toBeInstanceOf(NetworkError);
+        expect(error.message).toBe('Aborted');
+    });
+});
+
+describe('success responses', () => {
+    it('returns the parsed JSON payload', async () => {
+        fetchMock.mockResolvedValue(jsonResponse({ issues: [{ id: '1' }] }));
+        await expect(apiFetch('/issues/nearby')).resolves.toEqual({ issues: [{ id: '1' }] });
+    });
+
+    it('returns null for an empty body', async () => {
+        fetchMock.mockResolvedValue(textResponse('', 204));
+        await expect(apiFetch('/issues/x/upvote', { method: 'DELETE' })).resolves.toBeNull();
+    });
+});

--- a/mobile/src/api/auth.ts
+++ b/mobile/src/api/auth.ts
@@ -1,0 +1,19 @@
+// mobile/src/api/auth.ts
+import type { LoginResponse, User } from '@civickit/shared';
+import { apiFetch } from './client';
+
+export function login(email: string, password: string): Promise<LoginResponse> {
+    return apiFetch('/auth/login', { method: 'POST', body: { email, password } });
+}
+
+export function register(name: string, email: string, password: string): Promise<LoginResponse> {
+    return apiFetch('/auth/register', { method: 'POST', body: { name, email, password } });
+}
+
+/**
+ * `token` is passed explicitly by AuthProvider, which holds the token in state
+ * before the rest of the app is allowed to render.
+ */
+export function getCurrentUser(token?: string | null, signal?: AbortSignal): Promise<User> {
+    return apiFetch('/auth/user', { auth: true, token, signal });
+}

--- a/mobile/src/api/client.ts
+++ b/mobile/src/api/client.ts
@@ -1,0 +1,169 @@
+// mobile/src/api/client.ts
+import { getApiBaseUrl } from '../config/env';
+import { getToken } from '../services/tokenStorage';
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/** The server responded, but with a non-2xx status. */
+export class ApiError extends Error {
+    readonly status: number;
+    readonly body: unknown;
+
+    constructor(message: string, status: number, body: unknown) {
+        super(message);
+        this.name = 'ApiError';
+        this.status = status;
+        this.body = body;
+    }
+
+    get isUnauthorized(): boolean {
+        return this.status === 401;
+    }
+}
+
+/** The request never got a response — offline, DNS failure, or timeout. */
+export class NetworkError extends Error {
+    readonly cause?: unknown;
+
+    constructor(message: string, cause?: unknown) {
+        super(message);
+        this.name = 'NetworkError';
+        this.cause = cause;
+    }
+}
+
+type UnauthorizedHandler = () => void;
+
+let unauthorizedHandler: UnauthorizedHandler | null = null;
+
+/**
+ * Registered once by AuthProvider so that a token rejected mid-session tears
+ * down auth state instead of leaving the app stuck in a signed-in shell.
+ */
+export function setUnauthorizedHandler(handler: UnauthorizedHandler | null): void {
+    unauthorizedHandler = handler;
+}
+
+export type QueryParams = Record<string, string | number | boolean | undefined | null>;
+
+export interface ApiRequestOptions {
+    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+    query?: QueryParams;
+    /** Serialized as JSON. Omit for requests without a body. */
+    body?: unknown;
+    /** Attach a bearer token. Reads from SecureStore unless `token` is given. */
+    auth?: boolean;
+    /** Explicit token, for callers that already hold one (e.g. AuthProvider). */
+    token?: string | null;
+    timeoutMs?: number;
+    signal?: AbortSignal;
+}
+
+function buildUrl(path: string, query?: QueryParams): string {
+    const url = `${getApiBaseUrl()}${path.startsWith('/') ? path : `/${path}`}`;
+    if (!query) return url;
+
+    const pairs = Object.entries(query)
+        .filter(([, value]) => value !== undefined && value !== null && value !== '')
+        .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+
+    return pairs.length > 0 ? `${url}?${pairs.join('&')}` : url;
+}
+
+async function parseBody(response: Response): Promise<unknown> {
+    const text = await response.text();
+    if (!text) return null;
+    try {
+        return JSON.parse(text);
+    } catch {
+        return text;
+    }
+}
+
+/**
+ * The backend is not consistent about error shapes: the global error handler
+ * emits `{ success, message }`, while auth middleware and a few controllers
+ * emit `{ error }`. Accept both so the UI always has something to show.
+ */
+function extractErrorMessage(body: unknown, status: number): string {
+    if (body !== null && typeof body === 'object') {
+        for (const key of ['message', 'error'] as const) {
+            const value = (body as Record<string, unknown>)[key];
+            if (typeof value === 'string' && value.length > 0) return value;
+        }
+    }
+    if (typeof body === 'string' && body.trim().length > 0) return body;
+    return `Request failed with status ${status}`;
+}
+
+/**
+ * Single entry point for every backend call: resolves the base URL, attaches
+ * auth, enforces a timeout, and normalizes failures into ApiError/NetworkError.
+ */
+export async function apiFetch<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const {
+        method = 'GET',
+        query,
+        body,
+        auth = false,
+        token,
+        timeoutMs = DEFAULT_TIMEOUT_MS,
+        signal,
+    } = options;
+
+    // Resolved before the request so a misconfigured base URL surfaces its own
+    // error rather than being reported as an unreachable server.
+    const url = buildUrl(path, query);
+
+    const headers: Record<string, string> = { Accept: 'application/json' };
+
+    if (body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+    }
+
+    if (auth) {
+        // `token: null` is an explicit "no token"; omitting it reads SecureStore.
+        const bearer = token !== undefined ? token : await getToken();
+        if (!bearer) {
+            throw new ApiError('You are not signed in.', 401, null);
+        }
+        headers.Authorization = `Bearer ${bearer}`;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    const forwardAbort = () => controller.abort();
+    signal?.addEventListener('abort', forwardAbort);
+
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            method,
+            headers,
+            body: body === undefined ? undefined : JSON.stringify(body),
+            signal: controller.signal,
+        });
+    } catch (error) {
+        // A caller-initiated abort must stay an abort so React Query treats it
+        // as a cancellation rather than a failure.
+        if (signal?.aborted) throw error;
+        if (controller.signal.aborted) {
+            throw new NetworkError('The request timed out. Check your connection and try again.', error);
+        }
+        throw new NetworkError('Could not reach the server. Check your connection and try again.', error);
+    } finally {
+        clearTimeout(timeoutId);
+        signal?.removeEventListener('abort', forwardAbort);
+    }
+
+    const payload = await parseBody(response);
+
+    if (!response.ok) {
+        if (response.status === 401) {
+            unauthorizedHandler?.();
+        }
+        throw new ApiError(extractErrorMessage(payload, response.status), response.status, payload);
+    }
+
+    return payload as T;
+}

--- a/mobile/src/api/index.ts
+++ b/mobile/src/api/index.ts
@@ -1,0 +1,9 @@
+// mobile/src/api/index.ts
+export { ApiError, NetworkError, apiFetch, setUnauthorizedHandler } from './client';
+export type { ApiRequestOptions, QueryParams } from './client';
+
+export { queryKeys } from './queryKeys';
+
+export * as authApi from './auth';
+export * as issuesApi from './issues';
+export * as uploadApi from './upload';

--- a/mobile/src/api/issues.ts
+++ b/mobile/src/api/issues.ts
@@ -1,0 +1,94 @@
+// mobile/src/api/issues.ts
+import type { CreateIssueDTO, GetNearbyIssueResponse, Issue, User } from '@civickit/shared';
+import { apiFetch } from './client';
+
+export const METERS_PER_MILE = 1609.34;
+
+/**
+ * Shape actually returned by the issue *list* endpoints. This is deliberately
+ * not `Issue` from @civickit/shared: the backend includes the Prisma relation
+ * as `user` (not `author`) and adds a `_count`. Reconciling the two is a
+ * separate change — this type documents reality in the meantime.
+ */
+export interface IssueListItem extends Omit<Issue, 'author'> {
+    user: Pick<User, 'id' | 'name' | 'profileImage'>;
+    _count: { upvotes: number };
+}
+
+export interface IssueListResponse<T> {
+    issues: T[];
+}
+
+export interface UpvoteState {
+    upvoted: boolean;
+    upvoteCount: number;
+}
+
+export interface NearbyIssuesParams {
+    lat: number;
+    lng: number;
+    /** Search radius in miles; converted to the meters the API expects. */
+    radiusMiles: number;
+    limit?: number;
+    signal?: AbortSignal;
+}
+
+export function getNearbyIssues({
+    lat,
+    lng,
+    radiusMiles,
+    limit,
+    signal,
+}: NearbyIssuesParams): Promise<IssueListResponse<GetNearbyIssueResponse>> {
+    return apiFetch('/issues/nearby', {
+        query: {
+            lat,
+            lng,
+            radius: radiusMiles * METERS_PER_MILE,
+            limit,
+        },
+        signal,
+    });
+}
+
+export function getIssuesByUser(
+    userId: string,
+    options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<IssueListResponse<IssueListItem>> {
+    return apiFetch('/issues/user', {
+        query: { id: userId, limit: options.limit },
+        signal: options.signal,
+    });
+}
+
+export function getIssuesUpvotedByUser(
+    userId: string,
+    options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<IssueListResponse<IssueListItem>> {
+    return apiFetch('/issues/userUpvotes', {
+        query: { id: userId, limit: options.limit },
+        signal: options.signal,
+    });
+}
+
+export function createIssue(issue: Omit<CreateIssueDTO, 'status'>): Promise<Issue> {
+    return apiFetch('/issues/', { method: 'POST', body: issue, auth: true });
+}
+
+export function getUpvoteState(issueId: string, signal?: AbortSignal): Promise<UpvoteState> {
+    return apiFetch(`/issues/${encodeURIComponent(issueId)}/upvote`, { auth: true, signal });
+}
+
+export function addUpvote(issueId: string): Promise<UpvoteState> {
+    return apiFetch(`/issues/${encodeURIComponent(issueId)}/upvote`, {
+        method: 'POST',
+        auth: true,
+    });
+}
+
+export function removeUpvote(issueId: string): Promise<UpvoteState> {
+    return apiFetch(`/issues/${encodeURIComponent(issueId)}/upvote`, {
+        method: 'DELETE',
+        auth: true,
+    });
+}

--- a/mobile/src/api/queryKeys.ts
+++ b/mobile/src/api/queryKeys.ts
@@ -1,0 +1,23 @@
+// mobile/src/api/queryKeys.ts
+
+/**
+ * Every React Query key in the app is built here so that cache entries can be
+ * invalidated by prefix (e.g. `['issues']` clears every issue list) and so two
+ * screens fetching the same data actually share a cache entry.
+ */
+export const queryKeys = {
+    currentUser: (token: string | null) => ['user', token] as const,
+
+    issues: {
+        all: ['issues'] as const,
+        nearby: (params: { lat: number; lng: number; radiusMiles: number }) =>
+            ['issues', 'nearby', params] as const,
+        byUser: (userId: string | undefined) => ['issues', 'user', userId] as const,
+    },
+
+    upvotes: {
+        all: ['upvotes'] as const,
+        byUser: (userId: string | undefined) => ['upvotes', 'user', userId] as const,
+        forIssue: (issueId: string) => ['upvotes', 'issue', issueId] as const,
+    },
+} as const;

--- a/mobile/src/api/upload.ts
+++ b/mobile/src/api/upload.ts
@@ -1,0 +1,14 @@
+// mobile/src/api/upload.ts
+import { apiFetch } from './client';
+
+export interface UploadSignature {
+    signature: string;
+    timestamp: number;
+    cloudName: string;
+    apiKey: string;
+}
+
+/** Short-lived credentials for uploading straight to Cloudinary from the device. */
+export function getUploadSignature(): Promise<UploadSignature> {
+    return apiFetch('/upload/signature', { method: 'POST', auth: true });
+}

--- a/mobile/src/config/__tests__/env.test.ts
+++ b/mobile/src/config/__tests__/env.test.ts
@@ -1,0 +1,128 @@
+// mobile/src/config/__tests__/env.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const constantsMock: { expoConfig: any; expoGoConfig: any } = {
+    expoConfig: null,
+    expoGoConfig: null,
+};
+
+vi.mock('expo-constants', () => ({
+    get default() {
+        return constantsMock;
+    },
+}));
+
+/** env.ts caches its result, so each case needs a fresh module instance. */
+async function loadEnv(options: {
+    dev?: boolean;
+    hostUri?: string | null;
+    debuggerHost?: string | null;
+    apiUrl?: string;
+    apiPort?: string;
+}) {
+    vi.resetModules();
+    (globalThis as any).__DEV__ = options.dev ?? true;
+    constantsMock.expoConfig = options.hostUri ? { hostUri: options.hostUri } : {};
+    constantsMock.expoGoConfig = options.debuggerHost
+        ? { debuggerHost: options.debuggerHost }
+        : undefined;
+
+    if (options.apiUrl === undefined) delete process.env.EXPO_PUBLIC_API_URL;
+    else process.env.EXPO_PUBLIC_API_URL = options.apiUrl;
+
+    if (options.apiPort === undefined) delete process.env.EXPO_PUBLIC_API_PORT;
+    else process.env.EXPO_PUBLIC_API_PORT = options.apiPort;
+
+    return import('../env');
+}
+
+beforeEach(() => {
+    delete process.env.EXPO_PUBLIC_API_URL;
+    delete process.env.EXPO_PUBLIC_API_PORT;
+});
+
+afterEach(() => {
+    delete (globalThis as any).__DEV__;
+});
+
+describe('explicit configuration', () => {
+    it('uses EXPO_PUBLIC_API_URL when set', async () => {
+        const env = await loadEnv({ apiUrl: 'https://civickit.org/api' });
+        expect(env.getApiBaseUrl()).toBe('https://civickit.org/api');
+    });
+
+    it('strips trailing slashes so paths do not double up', async () => {
+        const env = await loadEnv({ apiUrl: 'https://civickit.org/api//' });
+        expect(env.getApiBaseUrl()).toBe('https://civickit.org/api');
+    });
+
+    it('wins over the Metro host, including in development', async () => {
+        const env = await loadEnv({
+            dev: true,
+            hostUri: '10.0.0.5:8081',
+            apiUrl: 'https://staging.civickit.org/api',
+        });
+        expect(env.getApiBaseUrl()).toBe('https://staging.civickit.org/api');
+    });
+
+    it('is the only source in a release build', async () => {
+        const env = await loadEnv({ dev: false, apiUrl: 'https://civickit.org/api' });
+        expect(env.getApiBaseUrl()).toBe('https://civickit.org/api');
+    });
+});
+
+describe('development host derivation', () => {
+    it('derives the API host from the Metro host', async () => {
+        const env = await loadEnv({ dev: true, hostUri: '10.0.0.5:8081' });
+        expect(env.getApiBaseUrl()).toBe('http://10.0.0.5:3000/api');
+    });
+
+    it('ignores a path segment on the Metro host', async () => {
+        const env = await loadEnv({ dev: true, hostUri: '10.0.0.5:8081/some/path' });
+        expect(env.getApiBaseUrl()).toBe('http://10.0.0.5:3000/api');
+    });
+
+    it('handles localhost', async () => {
+        const env = await loadEnv({ dev: true, hostUri: 'localhost:8081' });
+        expect(env.getApiBaseUrl()).toBe('http://localhost:3000/api');
+    });
+
+    it('honours EXPO_PUBLIC_API_PORT', async () => {
+        const env = await loadEnv({ dev: true, hostUri: '10.0.0.5:8081', apiPort: '4000' });
+        expect(env.getApiBaseUrl()).toBe('http://10.0.0.5:4000/api');
+    });
+
+    it('falls back to the Expo Go debuggerHost', async () => {
+        const env = await loadEnv({ dev: true, debuggerHost: '192.168.1.20:8081' });
+        expect(env.getApiBaseUrl()).toBe('http://192.168.1.20:3000/api');
+    });
+});
+
+describe('failure modes', () => {
+    it('throws a directing error when nothing is configured in a release build', async () => {
+        const env = await loadEnv({ dev: false });
+        expect(() => env.getApiBaseUrl()).toThrow(/EXPO_PUBLIC_API_URL/);
+    });
+
+    it('throws when development has no Metro host to work from', async () => {
+        const env = await loadEnv({ dev: true });
+        expect(() => env.getApiBaseUrl()).toThrow(/EXPO_PUBLIC_API_URL/);
+    });
+
+    it('defers resolution until first use rather than throwing on import', async () => {
+        // A misconfigured release build must surface through the app's normal
+        // request-failure UI, not crash during module initialization.
+        await expect(loadEnv({ dev: false })).resolves.toBeDefined();
+    });
+});
+
+describe('caching', () => {
+    it('resolves once and reuses the result', async () => {
+        const env = await loadEnv({ dev: true, hostUri: '10.0.0.5:8081' });
+        expect(env.getApiBaseUrl()).toBe('http://10.0.0.5:3000/api');
+
+        // A later Metro reconnection must not silently repoint the app mid-session.
+        constantsMock.expoConfig = { hostUri: '10.0.0.99:8081' };
+        expect(env.getApiBaseUrl()).toBe('http://10.0.0.5:3000/api');
+    });
+});

--- a/mobile/src/config/env.ts
+++ b/mobile/src/config/env.ts
@@ -59,13 +59,3 @@ export function getApiBaseUrl(): string {
     }
     return cachedBaseUrl;
 }
-
-// Getter rather than a plain field so resolution stays lazy for the existing
-// `ENV.apiUrl` call sites.
-const ENV = {
-    get apiUrl(): string {
-        return getApiBaseUrl();
-    },
-};
-
-export default ENV;

--- a/mobile/src/config/env.ts
+++ b/mobile/src/config/env.ts
@@ -1,25 +1,71 @@
-// mobile/src/config/env.tsx
-import local from './env.local.json'
+// mobile/src/config/env.ts
+import Constants from 'expo-constants';
 
-const ENV = {
-    dev: {
-        // apiUrl: 'http://localhost:3000/api',
-        apiUrl: 'http://' + local.domain + ':3000/api' //use this when no network errors
-        // apiUrl: 'https://quarters-elections-idea-restaurants.trycloudflare.com'+'/api' //cloudflare tunnel URL, should be replaced later
-    },
-    prod: {
-        apiUrl: 'https://civickit.loca.lt/api', //localtunnel URL, should be replaced later
-        //apiUrl: 'https://civickit.org/api'
-    },
-};
+const DEFAULT_API_PORT = '3000';
 
+/**
+ * The LAN host Metro is currently served from — the same machine running the
+ * backend during development. Expo already knows this because the device had
+ * to reach Metro to load the bundle, so there is nothing to configure by hand.
+ */
+function devHostFromExpo(): string | null {
+    const hostUri =
+        Constants.expoConfig?.hostUri ??
+        (Constants.expoGoConfig as { debuggerHost?: string } | undefined)?.debuggerHost;
 
-const getEnvVars = () => {
-    console.log(__DEV__)
-    if (__DEV__) {
-        return ENV.dev;
+    if (!hostUri) return null;
+
+    // hostUri looks like "10.0.0.5:8081" or "10.0.0.5:8081/some/path"
+    const host = hostUri.split('/')[0].split(':')[0];
+    return host || null;
+}
+
+/**
+ * Resolves the API base URL, in priority order:
+ *
+ *   1. EXPO_PUBLIC_API_URL — set this for staging, production, or a tunnel.
+ *   2. In development, derived from the Metro host + EXPO_PUBLIC_API_PORT.
+ *
+ * Fails loudly rather than falling back to a stale hardcoded URL. Resolution is
+ * lazy so a misconfigured build surfaces the error through the app's normal
+ * request-failure UI instead of crashing during module initialization.
+ */
+function resolveApiBaseUrl(): string {
+    const explicit = process.env.EXPO_PUBLIC_API_URL;
+    if (explicit) {
+        return explicit.replace(/\/+$/, '');
     }
-    return ENV.prod;
+
+    if (__DEV__) {
+        const host = devHostFromExpo();
+        if (host) {
+            const port = process.env.EXPO_PUBLIC_API_PORT ?? DEFAULT_API_PORT;
+            return `http://${host}:${port}/api`;
+        }
+    }
+
+    throw new Error(
+        'No API base URL available. Set EXPO_PUBLIC_API_URL (e.g. in mobile/.env) ' +
+        'to point the app at a backend. In development this is normally derived ' +
+        'from the Metro host automatically.',
+    );
+}
+
+let cachedBaseUrl: string | null = null;
+
+export function getApiBaseUrl(): string {
+    if (cachedBaseUrl === null) {
+        cachedBaseUrl = resolveApiBaseUrl();
+    }
+    return cachedBaseUrl;
+}
+
+// Getter rather than a plain field so resolution stays lazy for the existing
+// `ENV.apiUrl` call sites.
+const ENV = {
+    get apiUrl(): string {
+        return getApiBaseUrl();
+    },
 };
 
-export default getEnvVars();
+export default ENV;

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -3,7 +3,7 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { getToken, saveToken, deleteToken } from '../services/tokenStorage';
 import { User } from '@civickit/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { authApi, queryKeys } from '../api';
+import { authApi, queryKeys, setUnauthorizedHandler } from '../api';
 
 interface AuthContextType {
     isLoggedIn: boolean;
@@ -35,6 +35,21 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         })();
     }, []); //no dependencies bc it runs once on mount to check for token
 
+    //logout deletes token + updates state
+    const logout = async () => {
+        await deleteToken();
+        setAuthToken(null);
+        setUser(null)
+        setIsLoggedIn(false);
+        queryClient.clear();
+    };
+
+    // Any 401 from the API — including a token that expires mid-session —
+    // tears down auth state instead of leaving a signed-in shell that 401s.
+    useEffect(() => {
+        setUnauthorizedHandler(() => { void logout(); });
+        return () => setUnauthorizedHandler(null);
+    }, []);
 
     const { data, error } = useQuery({
         queryKey: queryKeys.currentUser(authToken),
@@ -47,13 +62,6 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         await saveToken(token);
         setAuthToken(token);
         setIsLoggedIn(true);
-    };
-    //logout deletes token + updates state
-    const logout = async () => {
-        await deleteToken();
-        setAuthToken(null);
-        setUser(null)
-        setIsLoggedIn(false);
     };
 
     if (error != null && isLoading == true) {

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -1,9 +1,9 @@
 //mobile/src/contexts/AuthContext.tsx
 import React, { createContext, useContext, useEffect, useState } from 'react';
-import { getToken, saveToken, deleteToken } from '../services/AuthService';
+import { getToken, saveToken, deleteToken } from '../services/tokenStorage';
 import { User } from '@civickit/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import ENV from "../config/env";
+import { authApi, queryKeys } from '../api';
 
 interface AuthContextType {
     isLoggedIn: boolean;
@@ -36,23 +36,10 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     }, []); //no dependencies bc it runs once on mount to check for token
 
 
-    const { data, error, refetch } = useQuery({
-        queryKey: ['user', authToken],
+    const { data, error } = useQuery({
+        queryKey: queryKeys.currentUser(authToken),
         enabled: !!authToken,
-        queryFn: async () => {
-            const response = await fetch(
-                ENV.apiUrl + '/auth/user',
-                { headers: { Authorization: `Bearer ${authToken}` } }
-            );
-            if (!response.ok) {
-                if (response.status == 401 || response.status == 404) {
-                    throw new Error('Invalid Token');
-                } else {
-                    throw new Error("Failed to Fetch")
-                }
-            }
-            return response.json()
-        },
+        queryFn: ({ signal }) => authApi.getCurrentUser(authToken, signal),
     }, queryClient);
 
     //login store token + update state

--- a/mobile/src/contexts/NearbyIssuesContext.tsx
+++ b/mobile/src/contexts/NearbyIssuesContext.tsx
@@ -1,11 +1,8 @@
 // mobile/src/contexts/NearbyIssuesContext.tsx
-import { QueryObserverResult, RefetchOptions, useQuery, useQueryClient } from "@tanstack/react-query";
+import { QueryObserverResult, RefetchOptions, keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createContext, useContext, useState } from "react";
 import { useLocation } from "./LocationContext";
-import { userLocation } from "../types/userLocation";
-import ENV from '../config/env';
-import LoadingScreen from "../screens/Misc/LoadingScreen";
-import { View, Text } from "react-native";
+import { issuesApi, queryKeys } from "../api";
 
 interface NearbyIssuesContextType {
     data: any;
@@ -23,20 +20,23 @@ export const NearbyIssuesProvider = ({ children }: any) => {
     const location = useLocation().location
     const [radius, setRadius] = useState<number>(5)
 
-    //fetch issues from database 
+    //fetch issues from database
     const { data, isLoading, isFetching, error, refetch } = useQuery({
-        queryKey: ['issues', 'nearby'],
-        queryFn: async () => {
-            console.log("url: ", ENV.apiUrl)
-            const response = await fetch(
-                ENV.apiUrl + '/issues/nearby?lat=' +
-                location.latitude + '&lng=' + location.longitude
-                + '&radius=' + radius * 1609.34 //1 mile
-            );
-            // console.log("fetch", response)
-            if (!response.ok) throw new Error('Failed to fetch');
-            return response.json();
-        }
+        queryKey: queryKeys.issues.nearby({
+            lat: location.latitude,
+            lng: location.longitude,
+            radiusMiles: radius,
+        }),
+        queryFn: ({ signal }) =>
+            issuesApi.getNearbyIssues({
+                lat: location.latitude,
+                lng: location.longitude,
+                radiusMiles: radius,
+                signal,
+            }),
+        // Consumers read `data.issues` directly; keep the last result on screen
+        // while a new location or radius loads instead of dropping to undefined.
+        placeholderData: keepPreviousData,
     }, queryClient);
 
     return (

--- a/mobile/src/hooks/useAuthToken.ts
+++ b/mobile/src/hooks/useAuthToken.ts
@@ -1,6 +1,6 @@
 //mobile/src/hooks/useAuthToken.ts
 import { useEffect, useState } from 'react';
-import { getToken } from '../services/AuthService';
+import { getToken } from '../services/tokenStorage';
 
 /**
  * Checks SecureStore on mount and returns whether a token exists.

--- a/mobile/src/screens/IssueCreation/IssueCreationScreen.tsx
+++ b/mobile/src/screens/IssueCreation/IssueCreationScreen.tsx
@@ -20,7 +20,7 @@ import Button from '../../components/Button';
 import IconButton from '../../components/IconButton';
 import SelectedImage from '../../components/SelectedImage';
 import ModalDropdown from '../../components/ModalDropdown';
-import ENV from '../../config/env';
+import { NetworkError, issuesApi } from '../../api';
 import { ImagesContext, PhotoMetadataContext, UserLocationContext, AddressContext, TitleContext, CategoryContext, DescriptionContext, FormStartedContext } from '../../contexts/FormContexts';
 import { userLocation } from '../../types/userLocation';
 import { PhotoMetadataSource } from '../../utils/photoMetadata';
@@ -193,7 +193,7 @@ export default function IssueCreationScreen() {
                         backgroundColor: palette.ckGreen,
                         color: colors.textContrast
                     });
-                    imageUrls = await uploadImagesToCloudinary(images, authToken);
+                    imageUrls = await uploadImagesToCloudinary(images);
                     performanceLog.times.imageUploadMs = Date.now() - imageUploadStartTime;
                 } catch (uploadError) {
                     setIsLoading(false);
@@ -220,22 +220,17 @@ export default function IssueCreationScreen() {
             };
 
             const backendStartTime = Date.now();
-            const response = await fetch(ENV.apiUrl + '/issues/', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${authToken}`,
-                },
-                body: JSON.stringify(requestBody)
-            });
+            let issue;
+            try {
+                issue = await issuesApi.createIssue(requestBody);
+            } catch (submitError) {
+                setIsLoading(false);
+                navigation.navigate('Error', { errorMessage: 'Upload Failed' });
+                throw submitError;
+            }
             performanceLog.times.backendSubmitMs = Date.now() - backendStartTime;
 
             setIsLoading(false);
-
-            if (!response.ok) {
-                navigation.navigate('Error', { errorMessage: 'Upload Failed' });
-                throw new Error("Issue could not be reported at this time");
-            }
 
             performanceLog.times.totalMs = Date.now() - totalStartTime;
             console.log('Issue Creation Performance:', performanceLog);
@@ -245,7 +240,6 @@ export default function IssueCreationScreen() {
                 backgroundColor: palette.ckGreen,
                 color: colors.textContrast
             });
-            const issue = await response.json();
             setImages([])
             setPhotoMetadata([])
             setLocation(null)
@@ -260,10 +254,11 @@ export default function IssueCreationScreen() {
             navigation.navigate('Issue Details', { issue: issue });
 
         } catch (error: any) {
-            if (error.message.includes("latitude") || error.message.includes("longtitude")) {
+            const message = String(error?.message ?? error)
+            if (message.includes("latitude") || message.includes("longitude")) {
                 navigation.navigate('Error', { errorMessage: 'Location permission denied' })
                 throw new Error("Location permission denied")
-            } else if (error.message.includes("network")) {
+            } else if (error instanceof NetworkError) {
                 navigation.navigate('Error', { errorMessage: 'NetworkError' })
                 throw new Error("Network Error")
             } else {

--- a/mobile/src/screens/Login/RegisterScreen.tsx
+++ b/mobile/src/screens/Login/RegisterScreen.tsx
@@ -17,7 +17,6 @@ import { StackParams } from '../../types/StackParams';
 import { registerUser } from '../../services/AuthService';
 import { useAuth } from '../../contexts/AuthContext';
 import { globalStyles } from '../../styles';
-import { loginUser } from '../../services/AuthService';
 import { colors, spacing, typography, borderRadius } from '../../styles/theme';
 // Validation
 const isValidEmail = (email: string) =>
@@ -92,8 +91,8 @@ export default function RegisterScreen() {
         try {
             console.log("handling register")
             setIsLoading(true);
-            const { token } = await registerUser(name.trim(), email.trim(), password);
-            const { user } = await loginUser(email.trim(), password);
+            // Registration already returns a signed-in session — no second login.
+            const { token, user } = await registerUser(name.trim(), email.trim(), password);
             setUser(user)
             await login(token);
         } catch (error: any) {

--- a/mobile/src/screens/Misc/IssueDetailScreen.tsx
+++ b/mobile/src/screens/Misc/IssueDetailScreen.tsx
@@ -6,9 +6,8 @@ import { GetNearbyIssueResponse, Issue } from '@civickit/shared';
 import { format, formatDistanceToNow } from 'date-fns';
 import { CategoryIcon, ClockIcon, LocationPinIcon, TagIcon, WrenchIcon } from '../../components/Icons';
 import { borderRadius, colors, globalStyles, palette, size, spacing, typography } from '../../styles';
-import { useAuth } from '../../contexts/AuthContext';
 import { PROVIDER_GOOGLE } from 'react-native-maps/lib/ProviderConstants';
-import ENV from '../../config/env';
+import { issuesApi } from '../../api';
 import Pin from '../../components/Pin';
 import { showLocation } from 'react-native-map-link';
 
@@ -39,34 +38,26 @@ const IssueDetailScreen = () => {
   const [activeImageIndex, setActiveImageIndex] = useState(0);
 
   const navigation = useNavigation();
-  const { authToken } = useAuth();
 
   const resolvedAddress = issue.address || 'No address available';
   const formatSource = (source?: string) => source === 'exif' ? 'Photo metadata' : 'Device GPS';
 
   useEffect(() => {
-    const fetchUpvoteState = async () => {
-      try {
-        const res = await fetch(
-          `${ENV.apiUrl}/issues/${issue.id}/upvote`,
-          {
-            headers: {
-              Authorization: `Bearer ${authToken}`,
-            },
-          }
-        );
+    const controller = new AbortController();
 
-        const data = await res.json();
+    issuesApi
+      .getUpvoteState(issue.id, controller.signal)
+      .then((state) => {
+        setHasEndorsed(state.upvoted);
+        setUpvoteCount(state.upvoteCount);
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        console.error('Failed to fetch upvote state:', err);
+      });
 
-        setHasEndorsed(data.upvoted);
-        setUpvoteCount(data.upvoteCount);
-      } catch (err) {
-        console.error("Failed to fetch upvote state:", err);
-      }
-    };
-
-    fetchUpvoteState();
-  }, []);
+    return () => controller.abort();
+  }, [issue.id]);
 
 
   const handleEndorse = async () => {
@@ -75,22 +66,12 @@ const IssueDetailScreen = () => {
     try {
       setLoading(true);
 
-      const method = hasEndorsed ? 'DELETE' : 'POST';
+      const state = hasEndorsed
+        ? await issuesApi.removeUpvote(issue.id)
+        : await issuesApi.addUpvote(issue.id);
 
-      const res = await fetch(
-        `${ENV.apiUrl}/issues/${issue.id}/upvote`,
-        {
-          method,
-          headers: {
-            Authorization: `Bearer ${authToken}`,
-          },
-        }
-      );
-
-      const data = await res.json();
-
-      setHasEndorsed(data.upvoted);
-      setUpvoteCount(data.upvoteCount);
+      setHasEndorsed(state.upvoted);
+      setUpvoteCount(state.upvoteCount);
 
     } catch (err) {
       console.error('Endorse failed:', err);

--- a/mobile/src/screens/Profile/ProfileScreen.tsx
+++ b/mobile/src/screens/Profile/ProfileScreen.tsx
@@ -12,7 +12,7 @@ import { StackParams } from "../../types/StackParams";
 import { StackNavigationProp } from "@react-navigation/stack";
 import { Image } from "expo-image";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import ENV from '../../config/env';
+import { issuesApi, queryKeys } from "../../api";
 import LoadingScreen from "../Misc/LoadingScreen";
 
 export default function ProfileScreen({ route }: any) {
@@ -28,31 +28,15 @@ export default function ProfileScreen({ route }: any) {
 
     const navigation = useNavigation<StackNavigationProp<StackParams>>();
     const issuesQuery = useQuery({
-        queryKey: ['issues', 'user'],
-        queryFn: async () => {
-            const response = await fetch(
-                ENV.apiUrl + '/issues/user?id=' +
-                user?.id
-            );
-
-
-            if (!response.ok) throw new Error('Failed to fetch');
-            return response.json()
-        }
+        queryKey: queryKeys.issues.byUser(user?.id),
+        enabled: !!user?.id,
+        queryFn: ({ signal }) => issuesApi.getIssuesByUser(user!.id, { signal }),
     }, queryClient);
 
     const upvotesQuery = useQuery({
-        queryKey: ['upvotes', 'user'],
-        queryFn: async () => {
-            const response = await fetch(
-                ENV.apiUrl + '/issues/userUpvotes?id=' +
-                user?.id
-            );
-
-
-            if (!response.ok) throw new Error('Failed to fetch');
-            return response.json()
-        }
+        queryKey: queryKeys.upvotes.byUser(user?.id),
+        enabled: !!user?.id,
+        queryFn: ({ signal }) => issuesApi.getIssuesUpvotedByUser(user!.id, { signal }),
     }, queryClient);
 
     const refetchQueries = () => {
@@ -91,7 +75,11 @@ export default function ProfileScreen({ route }: any) {
         )
     }
 
-
+    // Both queries stay disabled until the user id is known, so data can still
+    // be absent here without either query having errored.
+    if (issuesQuery.data == null || upvotesQuery.data == null) {
+        return <LoadingScreen />
+    }
 
     return (
         <ScrollView contentContainerStyle={[styles.container]}

--- a/mobile/src/screens/Stats/StatsScreen.tsx
+++ b/mobile/src/screens/Stats/StatsScreen.tsx
@@ -11,9 +11,9 @@ import { Issue } from "@civickit/shared";
 import CategoryPieChart from "../../components/CategoryPieChart";
 import ModalDropdown from "../../components/ModalDropdown";
 import { CaretDownIcon, RefreshIcon, RightArrowIcon } from "../../components/Icons";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "../../contexts/LocationContext";
-import ENV from '../../config/env';
+import { issuesApi, queryKeys } from "../../api";
 import { FlatList } from "react-native-gesture-handler";
 import { GetNearbyIssueResponse } from "@civickit/shared/src/types/api";
 import IconButton from "../../components/IconButton";
@@ -33,25 +33,28 @@ export default function StatsScreen() {
     const [time, setTime] = useState("All Time")
     const [statusNumbers, setStatusNumbers] = useState<record>({})
     const [categoryNumbers, setCategoryNumbers] = useState<record>({})
-    const [filteredData, setFilteredData] = useState([])
+    const [filteredData, setFilteredData] = useState<GetNearbyIssueResponse[]>([])
     const queryClient = useQueryClient()
     const location = useLocation().location
     const navigation = useNavigation<StackNavigationProp<StackParams>>()
 
-    async function queryFunction({ queryKey }: any) {
-        const [radius] = queryKey
-        const response = await fetch(
-            ENV.apiUrl + '/issues/nearby?lat=' +
-            location.latitude + '&lng=' + location.longitude
-            + '&radius=' + parseInt(radius) * 1609.34 //miles -> meters
-        );
-        if (!response.ok) throw new Error('Failed to fetch');
-        return response.json();
-    }
+    const radiusMiles = parseInt(radius)
 
     const { data, isLoading, error, refetch } = useQuery({
-        queryKey: [radius],
-        queryFn: queryFunction
+        queryKey: queryKeys.issues.nearby({
+            lat: location.latitude,
+            lng: location.longitude,
+            radiusMiles,
+        }),
+        queryFn: ({ signal }) =>
+            issuesApi.getNearbyIssues({
+                lat: location.latitude,
+                lng: location.longitude,
+                radiusMiles,
+                signal,
+            }),
+        // Keep the current chart data on screen while a new radius loads.
+        placeholderData: keepPreviousData,
     }, queryClient);
 
     useFocusEffect(

--- a/mobile/src/services/AuthService.ts
+++ b/mobile/src/services/AuthService.ts
@@ -1,73 +1,21 @@
 //mobile/src/services/AuthService.ts
-import * as SecureStore from 'expo-secure-store';
-import ENV from '../config/env';
-import { User } from '@civickit/shared';
+import type { LoginResponse } from '@civickit/shared';
+import * as authApi from '../api/auth';
 
-//reusable ket used to store/retrieve JWR token from secure storage
-export const AUTH_TOKEN_KEY = 'AUTH_TOKEN';
+export { AUTH_TOKEN_KEY, saveToken, getToken, deleteToken } from './tokenStorage';
 
-//represents a logged in user
-export interface AuthUser {
-    id: string;
-    name: string;
-    email: string;
-}
 //represents what the backend returns after login/register
-export interface AuthResponse {
-    token: string;
-    user: User;
-}
+export type AuthResponse = LoginResponse;
 
-// Token Storage 
-export const saveToken = async (token: string): Promise<void> => {
-    await SecureStore.setItemAsync(AUTH_TOKEN_KEY, token);
-};
-
-export const getToken = async (): Promise<string | null> => {
-    return await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
-};
-
-export const deleteToken = async (): Promise<void> => {
-    await SecureStore.deleteItemAsync(AUTH_TOKEN_KEY);
-};
-
-// API Calls
-export const registerUser = async (
+/**
+ * Registration signs the user in server-side and returns the same payload as
+ * login, so there is no need for a follow-up login request.
+ */
+export const registerUser = (
     name: string,
     email: string,
-    password: string
-): Promise<AuthResponse> => {
-    const response = await fetch(`${ENV.apiUrl}/auth/register`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name, email, password }),
-    });
-    const json = await response.json();
+    password: string,
+): Promise<AuthResponse> => authApi.register(name, email, password);
 
-    if (!response.ok) {
-        // Surface the server's error message (e.g. "Email already in use")
-        throw new Error(json?.message ?? 'Registration failed. Please try again.');
-    }
-
-    return json as AuthResponse;
-};
-
-export const loginUser = async (
-    email: string,
-    password: string
-): Promise<AuthResponse> => {
-    const response = await fetch(`${ENV.apiUrl}/auth/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, password }),
-    });
-
-    const json = await response.json();
-    console.log('Login response:', JSON.stringify(json));
-
-    if (!response.ok) {
-        throw new Error(json?.message ?? 'Login failed. Check your credentials.');
-    }
-
-    return json as AuthResponse;
-};
+export const loginUser = (email: string, password: string): Promise<AuthResponse> =>
+    authApi.login(email, password);

--- a/mobile/src/services/cloudinaryService.ts
+++ b/mobile/src/services/cloudinaryService.ts
@@ -1,17 +1,11 @@
 // mobile/src/services/cloudinaryService.ts
-import ENV from '../config/env';
+import { uploadApi } from '../api';
+import type { UploadSignature } from '../api/upload';
 
 interface CloudinaryUploadResponse {
     secure_url: string;
     public_id: string;
     [key: string]: any;
-}
-
-interface UploadSignature {
-    signature: string;
-    timestamp: number;
-    cloudName: string;
-    apiKey: string;
 }
 
 // Cache upload signatures briefly to avoid repeated backend requests
@@ -20,7 +14,7 @@ const SIGNATURE_CACHE_DURATION_MS = 5 * 60 * 1000; // Cache for 5 minutes
 
 // Get a signed upload token from the backend
 // This allows secure direct uploads to Cloudinary without exposing credentials
-async function getUploadSignature(authToken: string): Promise<UploadSignature> {
+async function getUploadSignature(): Promise<UploadSignature> {
     try {
         // Check if cached signature is still valid
         if (cachedSignature && Date.now() < cachedSignature.expiresAt) {
@@ -30,27 +24,15 @@ async function getUploadSignature(authToken: string): Promise<UploadSignature> {
         }
 
         const startTime = Date.now();
-        const response = await fetch(ENV.apiUrl + '/upload/signature', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'Authorization': `Bearer ${authToken}`,
-            },
-        });
-
-        if (!response.ok) {
-            throw new Error('Failed to get upload signature from server');
-        }
-
-        const result = await response.json();
+        const result = await uploadApi.getUploadSignature();
         const elapsed = Date.now() - startTime;
-        
+
         // Cache the signature with expiration time
         cachedSignature = {
             ...result,
             expiresAt: Date.now() + SIGNATURE_CACHE_DURATION_MS,
         };
-        
+
         console.log(`Signature Request: ${elapsed}ms (network + parse)`);
         return result;
     } catch (error) {
@@ -62,17 +44,14 @@ async function getUploadSignature(authToken: string): Promise<UploadSignature> {
 
 // Upload an image directly to Cloudinary from the mobile app using a signed request
 // Returns the secure URL of the uploaded image
-export async function uploadImageToCloudinary(
-    imageUri: string,
-    authToken: string
-): Promise<string> {
+export async function uploadImageToCloudinary(imageUri: string): Promise<string> {
     try {
         const uploadStartTime = Date.now();
         const timings = {} as any;
 
         // Step 1: Get signed upload credentials from backend
         const signatureStartTime = Date.now();
-        const uploadSignature = await getUploadSignature(authToken);
+        const uploadSignature = await getUploadSignature();
         timings.signatureMs = Date.now() - signatureStartTime;
 
         // Step 2: Create FormData with signed credentials
@@ -125,12 +104,9 @@ export async function uploadImageToCloudinary(
 
 // Upload multiple images to Cloudinary in parallel using signed requests
 // Returns an array of secure URLs
-export async function uploadImagesToCloudinary(
-    imageUris: string[],
-    authToken: string
-): Promise<string[]> {
+export async function uploadImagesToCloudinary(imageUris: string[]): Promise<string[]> {
     try {
-        const uploadPromises = imageUris.map(uri => uploadImageToCloudinary(uri, authToken));
+        const uploadPromises = imageUris.map(uri => uploadImageToCloudinary(uri));
         const urls = await Promise.all(uploadPromises);
         return urls;
     } catch (error) {

--- a/mobile/src/services/tokenStorage.ts
+++ b/mobile/src/services/tokenStorage.ts
@@ -1,0 +1,21 @@
+// mobile/src/services/tokenStorage.ts
+import * as SecureStore from 'expo-secure-store';
+
+/**
+ * Sole owner of the stored JWT. Kept separate from AuthService so the API
+ * client can read the token without importing the API surface back into
+ * itself.
+ */
+export const AUTH_TOKEN_KEY = 'AUTH_TOKEN';
+
+export const saveToken = async (token: string): Promise<void> => {
+    await SecureStore.setItemAsync(AUTH_TOKEN_KEY, token);
+};
+
+export const getToken = async (): Promise<string | null> => {
+    return await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
+};
+
+export const deleteToken = async (): Promise<void> => {
+    await SecureStore.deleteItemAsync(AUTH_TOKEN_KEY);
+};

--- a/mobile/startMac.sh
+++ b/mobile/startMac.sh
@@ -1,24 +1,17 @@
 #!/bin/bash
-#from mobile directory
-#./startWin.sh [localhost/ip]
+# from mobile directory
+#   ./startMac.sh          -> device/simulator on your LAN (recommended)
+#   ./startMac.sh localhost -> simulator only, backend on localhost
+#
+# The API base URL is derived from the Metro host automatically, so there is
+# nothing to configure by hand. Override it with EXPO_PUBLIC_API_URL when you
+# need to point at a tunnel or a deployed backend, e.g.
+#   EXPO_PUBLIC_API_URL=https://example.trycloudflare.com/api ./startMac.sh
 
-if [ $1 == "ip" ]; then
-    IP=$(ipconfig getifaddr en0)
-
-    cd src/config
-    jq -n --arg IP $IP '{"domain":$IP}' > env.local.json
-
-    echo starting with ip address
-    cd ../..
+if [ "$1" == "localhost" ]; then
+    echo "starting with localhost"
+    EXPO_PUBLIC_API_URL="http://localhost:3000/api" npx expo start
+else
+    echo "starting with LAN address from Metro"
     npx expo start
-elif [ $1 == "localhost" ]; then
-    LOCALHOST="localhost"
-    cd src/config
-    jq -n --arg LOCALHOST $LOCALHOST '{"domain":$LOCALHOST}' > env.local.json
-    
-    echo starting with localhost
-    cd ../..
-    npx expo start
-else 
-    echo specify either "./startMac localhost" or " ./startMac ip"
 fi

--- a/mobile/startWin.sh
+++ b/mobile/startWin.sh
@@ -1,44 +1,17 @@
 #!/bin/bash
-#from mobile directory
-#./startWin.sh [localhost/ip]
+# from mobile directory
+#   ./startWin.sh           -> device/emulator on your LAN (recommended)
+#   ./startWin.sh localhost -> emulator only, backend on localhost
+#
+# The API base URL is derived from the Metro host automatically, so there is
+# nothing to configure by hand. Override it with EXPO_PUBLIC_API_URL when you
+# need to point at a tunnel or a deployed backend, e.g.
+#   EXPO_PUBLIC_API_URL=https://example.trycloudflare.com/api ./startWin.sh
 
-if [ $1 == "ip" ]; then
-    IN_WIFI=false
-    IN_IPV4=false
-
-    OUTPUT=$(ipconfig)
-    for line in $OUTPUT;
-    do
-        if [ "$IN_WIFI" = true ]; then
-            if [ "$IN_IPV4" = true ]; then
-                if [[ "$line" =~ [[:digit:]]{1,3}.[[:digit:]]{1,3}.[[:digit:]]{1,3}.[[:digit:]]{1,3} ]]; then
-                    IP=${BASH_REMATCH[0]}
-
-                    cd src/config
-                    jq -n --arg IP $IP '{"domain":$IP}' > env.local.json
-
-                    echo starting with ip address
-                    cd ../..
-                    npx expo start
-                    break
-                fi
-            elif [[ "$line" =~ IPv4 ]]; then
-                IN_IPV4=true
-            fi
-        elif [[ "$line" =~ Wi-Fi ]]; then
-            IN_WIFI=true
-        fi
-    done
-
-elif [ $1 == "localhost" ]; then
-    LOCALHOST="localhost"
-    cd src/config
-    jq -n --arg LOCALHOST $LOCALHOST '{"domain":$LOCALHOST}' > env.local.json
-    
-    echo starting with localhost
-    cd ../..
+if [ "$1" == "localhost" ]; then
+    echo "starting with localhost"
+    EXPO_PUBLIC_API_URL="http://localhost:3000/api" npx expo start
+else
+    echo "starting with LAN address from Metro"
     npx expo start
-else 
-    echo specify either "./startWin localhost" or "./startWin ip"
 fi
-

--- a/mobile/vitest.config.ts
+++ b/mobile/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+// Unit tests only — these cover the plain-TypeScript layers (API client, env
+// resolution). Rendering React Native components would need jest-expo; that is
+// deliberately out of scope here.
+export default defineConfig({
+    test: {
+        environment: 'node',
+        include: ['src/**/__tests__/**/*.test.ts'],
+    },
+});


### PR DESCRIPTION
## Summary

Every screen built its own network call: eight files each hand-assembling a URL,
a bearer header, and an ad-hoc `if (!response.ok) throw new Error('Failed to fetch')`.
The base URL came from `env.local.json` — a gitignored file holding whichever
developer's LAN IP the start scripts last wrote there with `jq`.

This adds `mobile/src/api/`, makes it the only place that talks to the backend,
and removes the manual env step entirely.

No backend changes. No UI changes.

## Review in commit order

Each commit typechecks and bundles on its own, so you can stop after any one.

| | commit | what to expect |
|---|---|---|
| 1 | `derive API base URL from the Metro host` | small; deletes the `jq`/`env.local.json` dance |
| 2 | `add a typed API client` | large but mechanical — the bulk of the diff |
| 3 | `log out on 401 and stop retrying 4xx` | **32 lines, the only runtime behavior change — this is the one to scrutinize** |

Commit 1 keeps a temporary `ENV.apiUrl` default export so the not-yet-migrated
call sites still compile; commit 2 deletes it.

## Behavior changes (all in commit 3)

- **A 401 from any endpoint now logs you out.** Previously a token that expired
  mid-session left the app in a signed-in shell where every request silently
  failed. `logout()` also clears the query cache, so the next user on a shared
  device doesn't see the previous user's issues.
- **4xx responses are no longer retried.** A 401 cost four round trips before the
  error surfaced.
- **Registration no longer makes a second login request.** `/auth/register`
  already returns a token *and* a user, so the follow-up `loginUser` call was a
  wasted round trip and a second bcrypt compare server-side.

## How to test

```bash
cd backend && npm run dev     # needs the DB up: npm run db:up
cd mobile && npm install && ./startMac.sh
```

No `env.local.json` to create — the API host comes from the Metro host the device
already connected to. Worth exercising: sign in, report an issue with photos,
upvote/un-upvote from the detail screen, open Profile, change the radius on Stats.

For the 401 path: sign in, then restart the backend with a different `JWT_SECRET`.
Every request 401s and the app should drop you back to Login rather than sitting
on a broken signed-in screen.

## Verification and its limits

Typecheck and a full `expo export` pass at each of the three commits. I also added
a `typecheck` script to `mobile/package.json`, since mobile had no way to run one.

**Not verified:** this was never run against a live backend on a device or
simulator, and mobile has no tests. Backend CI will go green but covers none of
this — there is no CI job for `mobile/` at all. Response types are read off the
backend controllers, not observed traffic.

## Noticed, deliberately not fixed here

- `@civickit/shared`'s `Issue` declares `author`, but the list endpoints actually
  return `user` plus a Prisma `_count`. Nothing reads `.author` today so nothing
  breaks, but the shared types don't describe the real API. `IssueListItem` in
  `src/api/issues.ts` documents reality in the meantime.
- `axios` and `dotenv` are still in `mobile/package.json` with zero imports.
- `DuplicateCheckScreen` dereferences `data.issues` unguarded. `keepPreviousData`
  keeps that safe here, but the underlying fragility remains.
