### PR TITLE
repo: add a root task runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,36 @@ check installation with ```npm -v```
 git clone https://github.com/oss-slu/civickit.git
 cd civickit
 ```
-### 2. Go to [Setup Guide](docs/SETUP.md)
+### 2. One-time setup
+Installs every project's dependencies, creates `backend/.env`, and starts the database:
+```bash
+npm install
+npm run setup
+```
+Then fill in your Cloudinary values in `backend/.env` (image upload and seeding need them).
+
+### 3. Start everything
+```bash
+npm run dev
+```
+This runs the database, backend, mobile (Expo), and web together. Scan the Expo QR code
+with your phone to open the app.
+
+Useful variants:
+
+| command | what it does |
+|---|---|
+| `npm run dev` | database + backend + mobile + web |
+| `npm run dev:services` | database + backend + web only |
+| `npm run dev:backend` / `dev:mobile` / `dev:web` | one project on its own |
+| `npm run seed` | fill the database with sample issues |
+| `npm test` / `npm run typecheck` | run across all projects |
+
+Note: under `npm run dev`, Expo runs without an interactive terminal, so its keyboard
+shortcuts (`i`, `a`, `r`) do not work — the QR code and logs still do. To use them, run
+`npm run dev:services` in one terminal and `npm run dev:mobile` in another.
+
+For per-project detail, see the [Setup Guide](docs/SETUP.md).
 
 ## License
 MIT License

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -21,6 +21,36 @@ Notes:
 - `JWT_SECRET` must be at least 16 characters or the server refuses to start.
 - The `CLOUDINARY_*` values come from your Cloudinary dashboard. The server starts without them, but image upload and seeding will fail until they are filled in.
 
+## Quick Start (all projects)
+From the repository root:
+```bash
+npm install       # root task runner only
+npm run setup     # installs every project, creates backend/.env, starts the database
+npm run dev       # database + backend + mobile + web in one terminal
+```
+Fill in the `CLOUDINARY_*` values in `backend/.env` before uploading images or seeding.
+
+| command | what it does |
+|---|---|
+| `npm run dev` | database + backend + mobile + web |
+| `npm run dev:services` | database + backend + web only |
+| `npm run dev:backend` / `dev:mobile` / `dev:web` | one project on its own |
+| `npm run db:up` / `db:down` / `db:studio` | database container and Prisma Studio |
+| `npm run seed` / `seed:reset` | sample data |
+| `npm test` | tests across all projects |
+| `npm run typecheck` | typecheck across all projects |
+
+Two caveats worth knowing:
+- Under `npm run dev`, Expo is not attached to an interactive terminal, so its keyboard
+  shortcuts (`i`, `a`, `r`) do nothing. The QR code and logs work normally. For the
+  shortcuts, run `npm run dev:services` in one terminal and `npm run dev:mobile` in another.
+- `npm run typecheck` includes `web`, which needs `web/src/routeTree.gen.ts`. That file is
+  generated and gitignored, so on a fresh clone run `npm run dev:web` (or `cd web && npm run build`)
+  once before typechecking.
+
+The sections below cover each project individually, which is still the right path if you
+only want to work on one of them.
+
 ## Backend Setup
 1. Clone repo
 2. `cd backend`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,330 @@
+{
+  "name": "civickit",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "civickit",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "concurrently": "^9.2.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.4.tgz",
+      "integrity": "sha512-TZ0CEhyzvFjgtAvHTusDMgj7wNdihCh7LLLrzdUOXIhdlnL2JBBGA9eJxR24rtqgmdjh3OA3hrN1rCHj6HM8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.9.0",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "civickit",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Root task runner for the CivicKit backend, mobile, and web projects",
+  "license": "MIT",
+  "scripts": {
+    "setup": "npm run env:init && npm run install:all && npm run db:setup",
+    "env:init": "node -e \"const fs=require('fs');if(fs.existsSync('backend/.env')){console.log('backend/.env already exists, leaving it alone')}else{fs.copyFileSync('backend/.env.example','backend/.env');console.log('created backend/.env from .env.example -- fill in your Cloudinary values')}\"",
+    "install:all": "cd shared && npm install && cd ../backend && npm install && cd ../web && npm install && cd ../mobile && npm install",
+    "dev": "npm run db:up && concurrently -n backend,mobile,web -c blue,magenta,green \"npm:dev:backend\" \"npm:dev:mobile\" \"npm:dev:web\"",
+    "dev:services": "npm run db:up && concurrently -n backend,web -c blue,green \"npm:dev:backend\" \"npm:dev:web\"",
+    "dev:backend": "cd backend && npm run dev",
+    "dev:mobile": "cd mobile && npm start",
+    "dev:web": "cd web && npm run dev",
+    "db:up": "cd backend && npm run db:up",
+    "db:down": "cd backend && npm run db:down",
+    "db:setup": "cd backend && npm run db:setup",
+    "db:studio": "cd backend && npm run db:studio",
+    "seed": "cd backend && npm run seed:run",
+    "seed:reset": "cd backend && npm run seed:reset",
+    "test": "cd backend && npm test -- --run && cd ../mobile && npm test --if-present",
+    "typecheck": "cd backend && npm run typecheck && cd ../web && npm run typecheck && cd ../mobile && npm run typecheck --if-present"
+  },
+  "devDependencies": {
+    "concurrently": "^9.2.1"
+  }
+}

--- a/web/src/components/pageSections/SharedMap.tsx
+++ b/web/src/components/pageSections/SharedMap.tsx
@@ -1,7 +1,6 @@
 import { palette } from "@/lib/colors"
 import { Eye, Layers, ShieldCheck, TrendingUp } from "lucide-react"
 import Reveal from "../Reveal"
-import MapVisualization from "../MapVisualization"
 
 export default function SharedMap() {
     const benefits = [


### PR DESCRIPTION
## Summary

Starting the stack meant three terminals and remembering which directory each
command belonged to. There was no root `package.json` at all, so there was
nowhere to put a shared entry point.

```bash
npm install     # root task runner only
npm run setup   # installs all four projects, creates backend/.env, starts the DB
npm run dev     # database + backend + mobile + web
```

| command | what it does |
|---|---|
| `npm run dev` | database + backend + mobile + web |
| `npm run dev:services` | database + backend + web only |
| `npm run dev:backend` / `dev:mobile` / `dev:web` | one project on its own |
| `npm run db:up` / `db:down` / `db:setup` / `db:studio` | database + Prisma Studio |
| `npm run seed` / `seed:reset` | sample data |
| `npm test` / `npm run typecheck` | across all projects |

Existing per-project commands are untouched — nothing you already do stops working.

## Two decisions worth reviewing

**Expo loses its keyboard shortcuts under `npm run dev`.** It isn't attached to a
TTY when run through concurrently, so `i` / `a` / `r` do nothing. The QR code and
logs are unaffected. `npm run dev:services` + `npm run dev:mobile` in two terminals
gets them back, and that's documented in both the README and SETUP.md. I don't
think this is avoidable without spawning terminal windows, which isn't portable.

**No `--kill-others`.** The conventional default, but I hit two real cases while
testing where a failing Expo start (port 8081 busy, then a watchman error) killed
the backend and web servers along with it. A crash in one service shouldn't take
down your API. Ctrl-C still stops everything.

## Also in here

`web/src/components/pageSections/SharedMap.tsx` had an unused import that was the
only thing standing between `web` and a clean typecheck. Worth knowing that
`web`'s own `typecheck` script has apparently never been run — CI covers `backend`
only — so it had gone unnoticed.

## Verification

- `npm run typecheck` — passes across backend, web, mobile
- `npm test` — 70 backend tests pass, and it correctly runs vitest once instead of
  dropping into watch mode
- `npm run dev:services` — verified backend serves `/health` on :3000 and web
  responds 200, both under concurrently
- `npm run setup` / `install:all` — verified from a state where `web` and `shared`
  had no `node_modules`

**Not verified:** the mobile leg of `npm run dev` end to end. Watchman is blocked in
my sandbox, so Expo could not complete startup here. It does launch and reach
"Waiting on http://localhost:8081" — someone should confirm the QR code appears and
scans on a normal machine before this merges.

## Noticed, not fixed

`ALLOWED_ORIGINS` in `backend/.env.example` is `http://localhost:3001`, but Vite
actually serves `web` on 5173. Harmless today since `web` makes no API calls, but
it will bite the first person who adds one.
