### PR TITLE
Add Organization and OrgMembership models with PostGIS geofence

### DIFF
--- a/backend/prisma/migrations/20260727200100_add_organization_membership/migration.sql
+++ b/backend/prisma/migrations/20260727200100_add_organization_membership/migration.sql
@@ -1,0 +1,63 @@
+-- CreateEnum
+CREATE TYPE "OrgType" AS ENUM ('WARD_OFFICE', 'CID', 'BID', 'SBD', 'CDC', 'NONPROFIT', 'CITY_DEPARTMENT', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "OrgStatus" AS ENUM ('PENDING', 'ACTIVE', 'SUSPENDED');
+
+-- CreateEnum
+CREATE TYPE "OrgRole" AS ENUM ('ORG_ADMIN', 'ORG_MEMBER');
+
+-- CreateEnum
+CREATE TYPE "OrgTier" AS ENUM ('STARTER', 'GROWTH', 'FULLSCALE');
+
+-- CreateEnum
+CREATE TYPE "BoundarySource" AS ENUM ('OFFICIAL', 'UPLOADED', 'FREEHAND');
+
+-- CreateTable
+CREATE TABLE "Organization" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" "OrgType" NOT NULL,
+    "status" "OrgStatus" NOT NULL DEFAULT 'PENDING',
+    "tier" "OrgTier",
+    "categoryScope" "IssueCategory"[],
+    "boundarySource" "BoundarySource",
+    "geofence" geography(Polygon,4326),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Organization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "OrgMembership" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "role" "OrgRole" NOT NULL DEFAULT 'ORG_MEMBER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "OrgMembership_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "Organization_status_idx" ON "Organization"("status");
+
+-- CreateIndex (spatial GIST index on the PostGIS geofence column; not emitted
+-- automatically because `geofence` is a Prisma `Unsupported` type)
+CREATE INDEX "Organization_geofence_idx" ON "Organization" USING GIST ("geofence");
+
+-- CreateIndex
+CREATE INDEX "OrgMembership_organizationId_idx" ON "OrgMembership"("organizationId");
+
+-- CreateIndex
+CREATE INDEX "OrgMembership_userId_idx" ON "OrgMembership"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrgMembership_userId_organizationId_key" ON "OrgMembership"("userId", "organizationId");
+
+-- AddForeignKey
+ALTER TABLE "OrgMembership" ADD CONSTRAINT "OrgMembership_userId_fkey" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "OrgMembership" ADD CONSTRAINT "OrgMembership_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/migrations/20260727200100_add_organization_membership/migration.sql
+++ b/backend/prisma/migrations/20260727200100_add_organization_membership/migration.sql
@@ -22,7 +22,7 @@ CREATE TABLE "Organization" (
     "tier" "OrgTier",
     "categoryScope" "IssueCategory"[],
     "boundarySource" "BoundarySource",
-    "geofence" geography(Polygon,4326),
+    "geofence" geography(MultiPolygon,4326),
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
 

--- a/backend/prisma/migrations/20260802142723_add_org_slug_and_boundary_provenance/migration.sql
+++ b/backend/prisma/migrations/20260802142723_add_org_slug_and_boundary_provenance/migration.sql
@@ -1,0 +1,20 @@
+-- Add slug, boundary provenance, and a membership updatedAt column.
+-- Written to be safe whether or not the tables already hold rows: the two
+-- NOT NULL columns are added nullable, backfilled, then constrained.
+
+-- OrgMembership.updatedAt
+ALTER TABLE "OrgMembership" ADD COLUMN "updatedAt" TIMESTAMP(3);
+UPDATE "OrgMembership" SET "updatedAt" = "createdAt" WHERE "updatedAt" IS NULL;
+ALTER TABLE "OrgMembership" ALTER COLUMN "updatedAt" SET NOT NULL;
+
+-- Organization.slug -- backfilled from id, which is already unique
+ALTER TABLE "Organization" ADD COLUMN "slug" TEXT;
+UPDATE "Organization" SET "slug" = "id" WHERE "slug" IS NULL;
+ALTER TABLE "Organization" ALTER COLUMN "slug" SET NOT NULL;
+
+-- Organization boundary provenance
+ALTER TABLE "Organization" ADD COLUMN "boundaryRef" TEXT,
+                           ADD COLUMN "boundarySyncedAt" TIMESTAMP(3);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Organization_slug_key" ON "Organization"("slug");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -253,16 +253,21 @@ model Verification {
 }
 
 model Organization {
-  id             String                                       @id @default(cuid())
-  name           String
-  type           OrgType
-  status         OrgStatus                                    @default(PENDING)
-  tier           OrgTier?
-  categoryScope  IssueCategory[]
-  boundarySource BoundarySource?
-  geofence       Unsupported("geography(MultiPolygon,4326)")?
-  createdAt      DateTime                                     @default(now())
-  updatedAt      DateTime                                     @updatedAt
+  id               String                                       @id @default(cuid())
+  name             String
+  slug             String                                       @unique
+  type             OrgType
+  status           OrgStatus                                    @default(PENDING)
+  tier             OrgTier?
+  categoryScope    IssueCategory[]
+  // How the geofence was defined, and a reference back to its source so
+  // official boundaries can be re-synced when a city redistricts.
+  boundarySource   BoundarySource?
+  boundaryRef      String?
+  boundarySyncedAt DateTime?
+  geofence         Unsupported("geography(MultiPolygon,4326)")?
+  createdAt        DateTime                                     @default(now())
+  updatedAt        DateTime                                     @updatedAt
 
   memberships OrgMembership[]
 
@@ -276,6 +281,7 @@ model OrgMembership {
   organizationId String
   role           OrgRole  @default(ORG_MEMBER)
   createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
   organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -253,16 +253,16 @@ model Verification {
 }
 
 model Organization {
-  id             String                                  @id @default(cuid())
+  id             String                                       @id @default(cuid())
   name           String
   type           OrgType
-  status         OrgStatus                               @default(PENDING)
+  status         OrgStatus                                    @default(PENDING)
   tier           OrgTier?
   categoryScope  IssueCategory[]
   boundarySource BoundarySource?
-  geofence       Unsupported("geography(Polygon,4326)")?
-  createdAt      DateTime                                @default(now())
-  updatedAt      DateTime                                @updatedAt
+  geofence       Unsupported("geography(MultiPolygon,4326)")?
+  createdAt      DateTime                                     @default(now())
+  updatedAt      DateTime                                     @updatedAt
 
   memberships OrgMembership[]
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -267,6 +267,7 @@ model Organization {
   memberships OrgMembership[]
 
   @@index([status])
+  @@index([geofence], type: Gist)
 }
 
 model OrgMembership {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -36,9 +36,43 @@ enum EventStatus {
   CANCELLED
 }
 
-enum Role{
+enum Role {
   REPORTER
   ADMIN
+}
+
+enum OrgType {
+  WARD_OFFICE
+  CID
+  BID
+  SBD
+  CDC
+  NONPROFIT
+  CITY_DEPARTMENT
+  OTHER
+}
+
+enum OrgStatus {
+  PENDING
+  ACTIVE
+  SUSPENDED
+}
+
+enum OrgRole {
+  ORG_ADMIN
+  ORG_MEMBER
+}
+
+enum OrgTier {
+  STARTER
+  GROWTH
+  FULLSCALE
+}
+
+enum BoundarySource {
+  OFFICIAL
+  UPLOADED
+  FREEHAND
 }
 
 model User {
@@ -51,27 +85,28 @@ model User {
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 
-  issues     Issue[]
-  events     Event[]
-  timelineEntries    TimelineEntry[]
-  upvotes    Upvote[]
-  eventRsvps EventRsvp[]
+  issues          Issue[]
+  events          Event[]
+  timelineEntries TimelineEntry[]
+  upvotes         Upvote[]
+  eventRsvps      EventRsvp[]
 
-  emailVerified Boolean   @default(false)
+  emailVerified Boolean         @default(false)
   image         String?
   sessions      Session[]
   accounts      Account[]
+  memberships   OrgMembership[]
 
   @@index([email])
   @@map("user")
 }
 
 model Issue {
-  id                 String        @id @default(cuid())
+  id                 String          @id @default(cuid())
   title              String
   description        String
   category           IssueCategory
-  status             IssueStatus   @default(REPORTED)
+  status             IssueStatus     @default(REPORTED)
   // Location data
   latitude           Float
   longitude          Float
@@ -82,14 +117,14 @@ model Issue {
   // Media
   images             String[] // Array of Cloudinary URLs
   // Metadata
-  createdAt          DateTime      @default(now())
-  updatedAt          DateTime      @updatedAt
-  locationSource     String        @default("device")
+  createdAt          DateTime        @default(now())
+  updatedAt          DateTime        @updatedAt
+  locationSource     String          @default("device")
   photoTakenAt       DateTime?
-  photoTakenAtSource String        @default("device")
+  photoTakenAtSource String          @default("device")
   // Relationships
   userId             String
-  user               User          @relation(fields: [userId], references: [id])
+  user               User            @relation(fields: [userId], references: [id])
   timelineEntries    TimelineEntry[]
   upvotes            Upvote[]
   events             Event[]
@@ -103,14 +138,14 @@ model Issue {
 }
 
 model TimelineEntry {
-  id        String   @id @default(cuid())
+  id        String      @id @default(cuid())
   message   String
-  createdAt DateTime @default(now())
+  createdAt DateTime    @default(now())
   issueId   String
-  issue     Issue    @relation(fields: [issueId], references: [id], onDelete: Cascade)
+  issue     Issue       @relation(fields: [issueId], references: [id], onDelete: Cascade)
   userId    String
-  user      User     @relation(fields: [userId], references: [id])
-  status    IssueStatus   @default(REPORTED)
+  user      User        @relation(fields: [userId], references: [id])
+  status    IssueStatus @default(REPORTED)
   images    String[] // Array of Cloudinary URLs
 
   @@index([issueId])
@@ -215,4 +250,36 @@ model Verification {
 
   @@index([identifier])
   @@map("verification")
+}
+
+model Organization {
+  id             String                                  @id @default(cuid())
+  name           String
+  type           OrgType
+  status         OrgStatus                               @default(PENDING)
+  tier           OrgTier?
+  categoryScope  IssueCategory[]
+  boundarySource BoundarySource?
+  geofence       Unsupported("geography(Polygon,4326)")?
+  createdAt      DateTime                                @default(now())
+  updatedAt      DateTime                                @updatedAt
+
+  memberships OrgMembership[]
+
+  @@index([status])
+}
+
+model OrgMembership {
+  id             String   @id @default(cuid())
+  userId         String
+  organizationId String
+  role           OrgRole  @default(ORG_MEMBER)
+  createdAt      DateTime @default(now())
+
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, organizationId])
+  @@index([organizationId])
+  @@index([userId])
 }

--- a/docs/design-decisions/responder-model.md
+++ b/docs/design-decisions/responder-model.md
@@ -1,0 +1,246 @@
+# The responder model
+
+How organization members get their abilities and why it works that way.
+
+**Status:** the schema groundwork is in place — `Organization` and `OrgMembership`
+exist, with slug, boundary provenance, and membership timestamps. **The permission work
+described here is not built yet**, so today an org member still cannot update an issue's
+status. That is the gap this document exists to close.
+
+## What a responder is
+
+A responder is **anyone who belongs to an organization**. There is no `RESPONDER` value
+in the platform `Role` enum and there should not be one — membership in an org is what
+makes someone a responder, and it is what scopes them to that org.
+
+```
+User ──< OrgMembership >── Organization
+              │
+              └── OrgRole: ORG_ADMIN | ORG_MEMBER
+```
+
+## What a responder can do
+
+**Every member of an org can work issues — this is not limited to admins.** An ordinary
+`ORG_MEMBER` claims issues and updates their status. `ORG_ADMIN` is about running the
+organization, not about doing the work.
+
+| Ability | ORG_MEMBER | ORG_ADMIN | Scope |
+| --- | :---: | :---: | --- |
+| See issues in the org's service area | yes | yes | Anything inside the geofence, claimed or not |
+| Claim an issue | yes | yes | Must be in the service area |
+| Decline / refer an issue | yes | yes | Must be in the service area |
+| **Update issue status** | **yes** | **yes** | Only issues the org has claimed |
+| Post timeline updates | yes | yes | Only issues the org has claimed |
+| Invite / remove members | no | yes | Their own org |
+| Edit org settings and service area | no | yes | Their own org |
+
+The platform `ADMIN` role is a separate thing entirely — site-wide moderation, not org
+work. A responder never needs it.
+
+### Read scope and write scope deliberately differ
+
+| | Scope | Check |
+| --- | --- | --- |
+| **Read** | Service area | `ST_Covers(org.geofence, issue point)` |
+| **Write** | Claimed only | `issue.claimedByOrgId` is one of the user's orgs |
+
+They have to differ because of read-before-claim: a responder must be able to see an
+unclaimed issue in their area in order to claim it. If reads were also limited to
+claimed issues, the Dispatch feed would always be empty.
+
+Going the other way — allowing writes anywhere in the service area — lets two orgs with
+overlapping areas edit the same issue simultaneously with nothing arbitrating between
+them. The claim is what settles ownership.
+
+## Why membership-derived instead of a `RESPONDER` role
+
+Adding `RESPONDER` to the platform `Role` enum would slot into the existing permission
+map with almost no work. It was rejected because the platform role is global: a
+responder would then be able to update **any** issue on the platform, including issues
+belonging to other organizations. There is nothing in a global role that can express
+"only this org's issues."
+
+Scope has to come from the membership, because the membership is the only thing that
+knows which org a person belongs to.
+
+## How permissions work today, and why this currently breaks
+
+Permissions are a flat map keyed only by the platform role:
+
+```ts
+// backend/src/config/permissions.ts
+const reporter_perms = ['create:issue', 'create:upvote', 'read:upvote',
+                        'delete:upvote', 'create:upload_signature'];
+
+export const rolePermissions: Record<Role, string[]> = {
+    REPORTER: reporter_perms,
+    ADMIN: [...reporter_perms, 'update:issue_status'],
+};
+```
+
+The check that consumes it is resource-blind — it looks at who you are, never at what
+you are touching:
+
+```ts
+// backend/src/middleware/authorize.middleware.ts:22
+const allowed = rolePermissions[user.role];
+```
+
+**The concrete failure:** `update:issue_status` belongs to `ADMIN` only. An org member
+who is a platform `REPORTER` gets a **403** when updating an issue their own
+organization claimed. That is the wrong outcome, and it is the whole reason this
+document exists.
+
+## What has to change
+
+Two pieces:
+
+1. **An org-aware permission path** alongside the existing one. Given a request, it
+   needs to resolve which org the resource belongs to, confirm the user has an
+   `OrgMembership` in that org, and only then allow the action. The existing
+   `requirePermission` cannot express this because it never looks at the resource.
+
+2. **A claim field on `Issue`.** The write-scope check reads `issue.claimedByOrgId`,
+   **which does not exist yet.** Until an issue can record which org claimed it, there
+   is nothing to check writes against. This is the blocking dependency — the read path
+   (service-area filtering) can be built first, since it only needs the geofence query.
+
+3. **Updated authz tests.** The existing tests assert that a non-`ADMIN` is refused
+   `update:issue_status`. That assertion becomes wrong once org members can update the
+   status of issues their org claimed, and will need to encode the new rule instead.
+
+## Other decisions made alongside this
+
+### Tiers are labels; limits live in code
+
+`OrgTier { STARTER, GROWTH, FULLSCALE }` stays as-is. What a tier *grants* does not
+belong in the database:
+
+```ts
+// backend/src/config/tiers.ts  (does not exist yet)
+export const TIER_LIMITS = {
+  STARTER:   { seats: 3,    maxAreaKm2: 5,    features: [] },
+  GROWTH:    { seats: 15,   maxAreaKm2: 50,   features: ['reports'] },
+  FULLSCALE: { seats: null, maxAreaKm2: null, features: ['reports', 'api'] },
+};
+```
+
+The dimensions are still undecided — somewhere between seat count, geographic size, and
+feature gating. Names that encode a dimension (`SINGLE_DISTRICT`, `MULTI_SITE`) become
+false as soon as the dimension changes. `STARTER / GROWTH / FULLSCALE` never claimed to
+describe a mechanism, so they survive a change of mind, and changing what a tier grants
+is a code edit rather than a migration.
+
+If tiers do end up geography-based, measure **`ST_Area(geofence)`**, never a count of
+pieces. One org stores a single MultiPolygon that may contain several disjoint pieces, so
+a two-piece business district and a single ward bisected by a river both report
+`ST_NumGeometries = 2`.
+
+### Say "service area", not "district"
+
+`Issue.district` already exists and holds a neighborhood name (`'Midtown'` in the seed
+data). Reusing the word for org territory would give it two unrelated meanings in one
+schema. "District" also only fits wards and business districts — not nonprofits, park
+conservancies, or campuses. "Service area" is neutral across every org type.
+
+### Boundary provenance needs a reference
+
+`BoundarySource { OFFICIAL, UPLOADED, FREEHAND }` records *how* a geofence was created
+but not *which* source it came from. Two columns, now present on `Organization`:
+
+```prisma
+boundaryRef      String?    // OFFICIAL: "stl-open-data:wards-2023:ward-17"
+                            // UPLOADED: file URL or storage key
+                            // FREEHAND: null
+boundarySyncedAt DateTime?
+```
+
+Official boundaries go stale. St. Louis went from 28 wards to 14 in 2022. Without a
+reference there is no way to detect that, and issues quietly route to the wrong ward
+office with nothing surfacing the problem.
+
+### Organization slugs
+
+A slug is a short, URL-safe form of the organization's name — lowercase, hyphens for
+spaces, no punctuation or accents:
+
+| `name` | `slug` |
+| --- | --- |
+| Midtown CID | `midtown-cid` |
+| Ward 7 Office | `ward-7-office` |
+| Tower Grove Neighborhood Assoc. | `tower-grove-neighborhood-assoc` |
+
+**What it is for: addressability.** Every org already has a unique `id` (a cuid), and
+that is what guarantees two orgs are distinguishable — the slug does not add that. What
+the slug adds is a form that can appear in a URL a human will read, type, or paste:
+
+```
+/orgs/clx7k2p9q0000abcd1234efgh     — the id
+/orgs/midtown-cid                    — the slug
+```
+
+Both address the same row. Only one survives being pasted into a support ticket.
+
+`slug` is `UNIQUE` because it is used as a lookup key — `WHERE slug = 'midtown-cid'`
+must return exactly one row, or the URL is ambiguous. `name` is deliberately left
+unconstrained.
+
+**That combination relocates the duplicate-name problem rather than solving it.** Two
+orgs may both be named "Ward 7 Office", but they cannot both be `ward-7-office`; one
+becomes `ward-7-office-2` or `ward-7-office-stl`. This is the intended trade — a
+collision is resolved once, at signup, instead of a `UNIQUE` constraint on the display
+name hard-blocking a legitimate organization from registering at all.
+
+Two decisions the registration wizard still owes:
+
+1. **Collision strategy** — numeric suffix, city suffix, or prompt the user. A numeric
+   suffix is the usual default.
+2. **Rename behaviour** — when "Midtown CID" becomes "Midtown Community District", the
+   slug should **stay frozen** at its original value. Regenerating it breaks every saved
+   link and every URL anyone has shared. If slugs ever do need to follow the name, that
+   requires keeping the old slug as a redirect, not overwriting it.
+
+Neither is blocking, but the second is the one that causes damage quietly, and it is
+much cheaper to decide before orgs exist than after.
+
+### Smaller items
+
+Done:
+
+- `OrgMembership.updatedAt`, so role promotions and demotions leave a trace.
+
+Still to enforce in code:
+
+- An empty `categoryScope` means **routes nothing**, and org setup must require at least
+  one category. Defining empty as "all" would flood a misconfigured org.
+
+## Notes for the Drizzle migration
+
+The geofence is the fragile part. Carry these over deliberately:
+
+- **Column type** `geography(MultiPolygon,4326)`. MultiPolygon rather than Polygon
+  because business districts are assembled parcel-by-parcel and are routinely
+  non-contiguous, and city open-data exports are often authored as MultiPolygon
+  regardless. The overhead is a flat 8 bytes.
+- **A GIST index** on that column. Without one, every service-area lookup is a
+  sequential scan.
+- **Writes** must wrap single polygons in `ST_Multi(...)`; an unwrapped `Polygon` is
+  rejected by the column type.
+- **Reads** must stay in `geography` and use `ST_Covers` / `ST_Intersects`. Casting via
+  `geofence::geometry` produces a different expression than the indexed one and silently
+  falls back to a sequential scan.
+
+Drizzle can express both the custom column type and the GIST index directly, so the
+Prisma `Unsupported(...)` workaround does not need to carry over.
+
+## Known gaps
+
+- **Supabase:** the migration chain currently fails against a Supabase-style layout with
+  `type "geometry" does not exist`, because PostGIS lives in an `extensions` schema
+  rather than `public`. Fix is to include `extensions` on the `search_path`. Pre-existing
+  and unrelated to the org work.
+- **Row Level Security** is disabled on `Organization` and `OrgMembership`. Supabase
+  exposes tables to the anon key through PostgREST, and `OrgMembership` maps users to
+  orgs. The backend connects as table owner and bypasses RLS, so enabling it costs
+  nothing.

--- a/shared/src/enums/organization.d.ts
+++ b/shared/src/enums/organization.d.ts
@@ -1,0 +1,5 @@
+export type OrgType = 'WARD_OFFICE' | 'CID' | 'BID' | 'SBD' | 'CDC' | 'NONPROFIT' | 'CITY_DEPARTMENT' | 'OTHER';
+export type OrgStatus = 'PENDING' | 'ACTIVE' | 'SUSPENDED';
+export type OrgRole = 'ORG_ADMIN' | 'ORG_MEMBER';
+export type OrgTier = 'STARTER' | 'GROWTH' | 'FULLSCALE';
+export type BoundarySource = 'OFFICIAL' | 'UPLOADED' | 'FREEHAND';

--- a/shared/src/enums/organization.js
+++ b/shared/src/enums/organization.js
@@ -1,0 +1,3 @@
+"use strict";
+// shared/src/enums/organization.ts
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/shared/src/enums/organization.ts
+++ b/shared/src/enums/organization.ts
@@ -1,0 +1,16 @@
+// shared/src/enums/organization.ts
+
+export type OrgType =
+    | 'WARD_OFFICE'
+    | 'CID'
+    | 'BID'
+    | 'SBD'
+    | 'CDC'
+    | 'NONPROFIT'
+    | 'CITY_DEPARTMENT'
+    | 'OTHER';
+
+export type OrgStatus = 'PENDING' | 'ACTIVE' | 'SUSPENDED';
+export type OrgRole = 'ORG_ADMIN' | 'ORG_MEMBER';
+export type OrgTier = 'STARTER' | 'GROWTH' | 'FULLSCALE';
+export type BoundarySource = 'OFFICIAL' | 'UPLOADED' | 'FREEHAND';

--- a/shared/src/index.d.ts
+++ b/shared/src/index.d.ts
@@ -1,5 +1,6 @@
 export { EventStatus, RsvpStatus } from './enums/event';
 export { IssueCategory, IssueStatus } from './enums/issue';
+export { OrgType, OrgStatus, OrgRole, OrgTier, BoundarySource } from './enums/organization';
 export { ApiResponse, CreateIssueDTO, LoginDTO, LoginResponse, CreateAuthDTO, GetNearbyIssueResponse } from './types/api';
 export { Event, EventRsvp } from './types/event';
 export { Issue, Upvote } from './types/issue';

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -9,6 +9,14 @@ export {
 } from './enums/issue'
 
 export {
+    OrgType,
+    OrgStatus,
+    OrgRole,
+    OrgTier,
+    BoundarySource
+} from './enums/organization'
+
+export {
     ApiResponse,
     CreateIssueDTO,
     PostUpdateDTO,


### PR DESCRIPTION
## Add the Organization / OrgMembership data model

Groundwork for **responders** — people who belong to a civic organization (ward office, business district, nonprofit) and handle issues in their area. Data model only: no routes, services, or UI.

### What's in here

- **`Organization`** — `id`, `name`, `slug`, `type`, `status`, `tier`, `categoryScope`, `boundarySource`, `boundaryRef`, `boundarySyncedAt`, `geofence`, timestamps.
- **`OrgMembership`** — joins `User` ↔ `Organization` with an `ORG_ADMIN` / `ORG_MEMBER` role, unique on `(userId, organizationId)`.
- **Five enums** — `OrgType`, `OrgStatus`, `OrgRole`, `OrgTier`, `BoundarySource`, mirrored into `@civickit/shared` as TS union types.
- **A real PostGIS geofence** — `geography(MultiPolygon,4326)`, an actual polygon on the earth's surface. Answers "which orgs cover this issue?"
- **`docs/design-decisions/responder-model.md`** — read this before building on the model.

### Gotchas

**1. Prisma Client cannot see `geofence`.** Prisma has no PostGIS support, so it's declared `Unsupported(...)` and excluded from the generated client. `prisma.organization.findMany()` returns everything *except* the geofence, and Prisma Studio won't show it. Use `$queryRaw` for anything geofence-related.

**2. Writes need `ST_Multi()`.** A bare `POLYGON` is rejected — the column is MultiPolygon because business districts are often not one connected shape.

```sql
ST_Multi(ST_GeomFromText('POLYGON((...))', 4326))::geography
```

`ST_Multi` operates on `geometry`, so build the geometry first and cast after — not `ST_GeogFromText`.

**3. Reads must use `ST_Covers`, never `::geometry`.** There's a GIST index, and it only applies if you stay in `geography`:

```sql
ST_Covers(geofence, ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography)  --  (YES) Index Scan
ST_Contains(geofence::geometry, ST_MakePoint(lng, lat))                   -- (NO) Seq Scan
```

Both give correct answers; the second just scans every org, so the problem stays invisible until it isn't.

**4. `slug` is `NOT NULL` + `UNIQUE`.** Every insert needs one (`Midtown CID` → `midtown-cid`), so orgs get readable URLs instead of a raw cuid. `name` is deliberately *not* unique — two cities can each have a "Ward 7 Office".

### Running it locally

```bash
cd backend && npm run db:up && npx prisma migrate deploy && npx prisma generate
```

No org seed data yet — create one by hand to experiment:

```sql
INSERT INTO "Organization" (id,name,slug,type,status,"categoryScope",geofence,"createdAt","updatedAt")
VALUES ('demo','Demo Ward','demo-ward','WARD_OFFICE','ACTIVE',
  ARRAY['POTHOLE','STREETLIGHT']::"IssueCategory"[],
  ST_Multi(ST_GeomFromText('POLYGON((-90.26 38.63,-90.24 38.63,-90.24 38.65,-90.26 38.65,-90.26 38.63))',4326))::geography,
  now(),now());
```

### Not in this PR

Nothing reads these tables yet. **Responders still can't update issue status** — `update:issue_status` belongs to the platform `ADMIN` role and the permission layer has no concept of org membership, so an org member gets a 403 on their own org's issues. The fix is written up in the design doc and needs a claim field on `Issue` first. The platform `Role` enum is deliberately untouched.

### Known gaps

- **Supabase:** migrations fail there with `type "geometry" does not exist` (PostGIS lives in an `extensions` schema). Fix is adding `extensions` to the `search_path`. Pre-existing — fails on an older migration, not this work.
- **RLS is off** on both new tables; worth enabling before anything is exposed via PostgREST.

### Verification

Typecheck exit 0 · 81/81 tests · `migrate status` up to date · no schema/DB drift · fresh-database `migrate deploy` reproduces the column, the GIST index, and a working MultiPolygon insert.