### PR TITLE
issue claiming and organization routes

### DIFF
--- a/backend/drizzle/0001_wonderful_rumiko_fujikawa.sql
+++ b/backend/drizzle/0001_wonderful_rumiko_fujikawa.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Issue" ADD COLUMN "claimedById" text;

--- a/backend/drizzle/0002_melodic_stellaris.sql
+++ b/backend/drizzle/0002_melodic_stellaris.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."Role" ADD VALUE 'ORG_MEMBER';

--- a/backend/drizzle/0003_lumpy_franklin_storm.sql
+++ b/backend/drizzle/0003_lumpy_franklin_storm.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "user" ALTER COLUMN "role" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'REPORTER'::text;--> statement-breakpoint
+DROP TYPE "public"."Role";--> statement-breakpoint
+CREATE TYPE "public"."Role" AS ENUM('REPORTER', 'ADMIN');--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "role" SET DEFAULT 'REPORTER'::"public"."Role";--> statement-breakpoint
+ALTER TABLE "user" ALTER COLUMN "role" SET DATA TYPE "public"."Role" USING "role"::"public"."Role";

--- a/backend/drizzle/0004_married_warlock.sql
+++ b/backend/drizzle/0004_married_warlock.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Organization" ADD COLUMN "profileImage" text;

--- a/backend/drizzle/meta/0001_snapshot.json
+++ b/backend/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1470 @@
+{
+  "id": "be9b40c9-8745-4aa7-93a8-c9180d605f43",
+  "prevId": "5296fc8f-c301-4494-955a-3198c8a6f887",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EventRsvp": {
+      "name": "EventRsvp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EventRsvp_eventId_userId_key": {
+          "name": "EventRsvp_eventId_userId_key",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EventRsvp_eventId_idx": {
+          "name": "EventRsvp_eventId_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EventRsvp_eventId_Event_id_fk": {
+          "name": "EventRsvp_eventId_Event_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "Event",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EventRsvp_userId_user_id_fk": {
+          "name": "EventRsvp_userId_user_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "EventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PLANNED'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizerId": {
+          "name": "organizerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Event_startTime_idx": {
+          "name": "Event_startTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_status_idx": {
+          "name": "Event_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizerId_user_id_fk": {
+          "name": "Event_organizerId_user_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "organizerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Event_issueId_Issue_id_fk": {
+          "name": "Event_issueId_Issue_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Issue": {
+      "name": "Issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "IssueCategory",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district": {
+          "name": "district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subregion": {
+          "name": "subregion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locationSource": {
+          "name": "locationSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "photoTakenAt": {
+          "name": "photoTakenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photoTakenAtSource": {
+          "name": "photoTakenAtSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cityRefNumber": {
+          "name": "cityRefNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedById": {
+          "name": "claimedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Issue_latitude_longitude_idx": {
+          "name": "Issue_latitude_longitude_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_status_idx": {
+          "name": "Issue_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_category_idx": {
+          "name": "Issue_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_createdAt_idx": {
+          "name": "Issue_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Issue_userId_user_id_fk": {
+          "name": "Issue_userId_user_id_fk",
+          "tableFrom": "Issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrgMembership": {
+      "name": "OrgMembership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrgRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORG_MEMBER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrgMembership_userId_organizationId_key": {
+          "name": "OrgMembership_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_organizationId_idx": {
+          "name": "OrgMembership_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_userId_idx": {
+          "name": "OrgMembership_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrgMembership_userId_user_id_fk": {
+          "name": "OrgMembership_userId_user_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrgMembership_organizationId_Organization_id_fk": {
+          "name": "OrgMembership_organizationId_Organization_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "OrgType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrgStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "OrgTier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categoryScope": {
+          "name": "categoryScope",
+          "type": "IssueCategory[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "boundarySource": {
+          "name": "boundarySource",
+          "type": "BoundarySource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundaryRef": {
+          "name": "boundaryRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundarySyncedAt": {
+          "name": "boundarySyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geofence": {
+          "name": "geofence",
+          "type": "geography(MultiPolygon,4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Organization_status_idx": {
+          "name": "Organization_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_geofence_idx": {
+          "name": "Organization_geofence_idx",
+          "columns": [
+            {
+              "expression": "geofence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_key": {
+          "name": "Organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEntry": {
+      "name": "TimelineEntry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "TimelineEntry_issueId_idx": {
+          "name": "TimelineEntry_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEntry_createdAt_idx": {
+          "name": "TimelineEntry_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEntry_issueId_Issue_id_fk": {
+          "name": "TimelineEntry_issueId_Issue_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TimelineEntry_userId_user_id_fk": {
+          "name": "TimelineEntry_userId_user_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Upvote": {
+      "name": "Upvote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Upvote_issueId_userId_key": {
+          "name": "Upvote_issueId_userId_key",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Upvote_issueId_idx": {
+          "name": "Upvote_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Upvote_issueId_Issue_id_fk": {
+          "name": "Upvote_issueId_Issue_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Upvote_userId_user_id_fk": {
+          "name": "Upvote_userId_user_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileImage": {
+          "name": "profileImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_key": {
+          "name": "user_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.BoundarySource": {
+      "name": "BoundarySource",
+      "schema": "public",
+      "values": [
+        "OFFICIAL",
+        "UPLOADED",
+        "FREEHAND"
+      ]
+    },
+    "public.EventStatus": {
+      "name": "EventStatus",
+      "schema": "public",
+      "values": [
+        "PLANNED",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.IssueCategory": {
+      "name": "IssueCategory",
+      "schema": "public",
+      "values": [
+        "POTHOLE",
+        "STREETLIGHT",
+        "GRAFFITI",
+        "ILLEGAL_DUMPING",
+        "BROKEN_SIDEWALK",
+        "TRAFFIC_SIGNAL",
+        "OTHER"
+      ]
+    },
+    "public.IssueStatus": {
+      "name": "IssueStatus",
+      "schema": "public",
+      "values": [
+        "REPORTED",
+        "ACKNOWLEDGED",
+        "IN_PROGRESS",
+        "RESOLVED",
+        "CLOSED",
+        "COMMUNITY_RESOLVED"
+      ]
+    },
+    "public.OrgRole": {
+      "name": "OrgRole",
+      "schema": "public",
+      "values": [
+        "ORG_ADMIN",
+        "ORG_MEMBER"
+      ]
+    },
+    "public.OrgStatus": {
+      "name": "OrgStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACTIVE",
+        "SUSPENDED"
+      ]
+    },
+    "public.OrgTier": {
+      "name": "OrgTier",
+      "schema": "public",
+      "values": [
+        "STARTER",
+        "GROWTH",
+        "FULLSCALE"
+      ]
+    },
+    "public.OrgType": {
+      "name": "OrgType",
+      "schema": "public",
+      "values": [
+        "WARD_OFFICE",
+        "CID",
+        "BID",
+        "SBD",
+        "CDC",
+        "NONPROFIT",
+        "CITY_DEPARTMENT",
+        "OTHER"
+      ]
+    },
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": [
+        "REPORTER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0002_snapshot.json
+++ b/backend/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1471 @@
+{
+  "id": "0683863f-0298-46e2-91ad-9f7fb37a77e8",
+  "prevId": "be9b40c9-8745-4aa7-93a8-c9180d605f43",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EventRsvp": {
+      "name": "EventRsvp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EventRsvp_eventId_userId_key": {
+          "name": "EventRsvp_eventId_userId_key",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EventRsvp_eventId_idx": {
+          "name": "EventRsvp_eventId_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EventRsvp_eventId_Event_id_fk": {
+          "name": "EventRsvp_eventId_Event_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "Event",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EventRsvp_userId_user_id_fk": {
+          "name": "EventRsvp_userId_user_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "EventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PLANNED'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizerId": {
+          "name": "organizerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Event_startTime_idx": {
+          "name": "Event_startTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_status_idx": {
+          "name": "Event_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizerId_user_id_fk": {
+          "name": "Event_organizerId_user_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "organizerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Event_issueId_Issue_id_fk": {
+          "name": "Event_issueId_Issue_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Issue": {
+      "name": "Issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "IssueCategory",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district": {
+          "name": "district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subregion": {
+          "name": "subregion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locationSource": {
+          "name": "locationSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "photoTakenAt": {
+          "name": "photoTakenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photoTakenAtSource": {
+          "name": "photoTakenAtSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cityRefNumber": {
+          "name": "cityRefNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedById": {
+          "name": "claimedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Issue_latitude_longitude_idx": {
+          "name": "Issue_latitude_longitude_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_status_idx": {
+          "name": "Issue_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_category_idx": {
+          "name": "Issue_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_createdAt_idx": {
+          "name": "Issue_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Issue_userId_user_id_fk": {
+          "name": "Issue_userId_user_id_fk",
+          "tableFrom": "Issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrgMembership": {
+      "name": "OrgMembership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrgRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORG_MEMBER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrgMembership_userId_organizationId_key": {
+          "name": "OrgMembership_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_organizationId_idx": {
+          "name": "OrgMembership_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_userId_idx": {
+          "name": "OrgMembership_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrgMembership_userId_user_id_fk": {
+          "name": "OrgMembership_userId_user_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrgMembership_organizationId_Organization_id_fk": {
+          "name": "OrgMembership_organizationId_Organization_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "OrgType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrgStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "OrgTier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categoryScope": {
+          "name": "categoryScope",
+          "type": "IssueCategory[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "boundarySource": {
+          "name": "boundarySource",
+          "type": "BoundarySource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundaryRef": {
+          "name": "boundaryRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundarySyncedAt": {
+          "name": "boundarySyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geofence": {
+          "name": "geofence",
+          "type": "geography(MultiPolygon,4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Organization_status_idx": {
+          "name": "Organization_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_geofence_idx": {
+          "name": "Organization_geofence_idx",
+          "columns": [
+            {
+              "expression": "geofence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_key": {
+          "name": "Organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEntry": {
+      "name": "TimelineEntry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "TimelineEntry_issueId_idx": {
+          "name": "TimelineEntry_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEntry_createdAt_idx": {
+          "name": "TimelineEntry_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEntry_issueId_Issue_id_fk": {
+          "name": "TimelineEntry_issueId_Issue_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TimelineEntry_userId_user_id_fk": {
+          "name": "TimelineEntry_userId_user_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Upvote": {
+      "name": "Upvote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Upvote_issueId_userId_key": {
+          "name": "Upvote_issueId_userId_key",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Upvote_issueId_idx": {
+          "name": "Upvote_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Upvote_issueId_Issue_id_fk": {
+          "name": "Upvote_issueId_Issue_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Upvote_userId_user_id_fk": {
+          "name": "Upvote_userId_user_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileImage": {
+          "name": "profileImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_key": {
+          "name": "user_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.BoundarySource": {
+      "name": "BoundarySource",
+      "schema": "public",
+      "values": [
+        "OFFICIAL",
+        "UPLOADED",
+        "FREEHAND"
+      ]
+    },
+    "public.EventStatus": {
+      "name": "EventStatus",
+      "schema": "public",
+      "values": [
+        "PLANNED",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.IssueCategory": {
+      "name": "IssueCategory",
+      "schema": "public",
+      "values": [
+        "POTHOLE",
+        "STREETLIGHT",
+        "GRAFFITI",
+        "ILLEGAL_DUMPING",
+        "BROKEN_SIDEWALK",
+        "TRAFFIC_SIGNAL",
+        "OTHER"
+      ]
+    },
+    "public.IssueStatus": {
+      "name": "IssueStatus",
+      "schema": "public",
+      "values": [
+        "REPORTED",
+        "ACKNOWLEDGED",
+        "IN_PROGRESS",
+        "RESOLVED",
+        "CLOSED",
+        "COMMUNITY_RESOLVED"
+      ]
+    },
+    "public.OrgRole": {
+      "name": "OrgRole",
+      "schema": "public",
+      "values": [
+        "ORG_ADMIN",
+        "ORG_MEMBER"
+      ]
+    },
+    "public.OrgStatus": {
+      "name": "OrgStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACTIVE",
+        "SUSPENDED"
+      ]
+    },
+    "public.OrgTier": {
+      "name": "OrgTier",
+      "schema": "public",
+      "values": [
+        "STARTER",
+        "GROWTH",
+        "FULLSCALE"
+      ]
+    },
+    "public.OrgType": {
+      "name": "OrgType",
+      "schema": "public",
+      "values": [
+        "WARD_OFFICE",
+        "CID",
+        "BID",
+        "SBD",
+        "CDC",
+        "NONPROFIT",
+        "CITY_DEPARTMENT",
+        "OTHER"
+      ]
+    },
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": [
+        "REPORTER",
+        "ADMIN",
+        "ORG_MEMBER"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0003_snapshot.json
+++ b/backend/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1470 @@
+{
+  "id": "372ef1c1-4ee3-4674-b29c-a67185266abc",
+  "prevId": "0683863f-0298-46e2-91ad-9f7fb37a77e8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EventRsvp": {
+      "name": "EventRsvp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EventRsvp_eventId_userId_key": {
+          "name": "EventRsvp_eventId_userId_key",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EventRsvp_eventId_idx": {
+          "name": "EventRsvp_eventId_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EventRsvp_eventId_Event_id_fk": {
+          "name": "EventRsvp_eventId_Event_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "Event",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EventRsvp_userId_user_id_fk": {
+          "name": "EventRsvp_userId_user_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "EventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PLANNED'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizerId": {
+          "name": "organizerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Event_startTime_idx": {
+          "name": "Event_startTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_status_idx": {
+          "name": "Event_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizerId_user_id_fk": {
+          "name": "Event_organizerId_user_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "organizerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Event_issueId_Issue_id_fk": {
+          "name": "Event_issueId_Issue_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Issue": {
+      "name": "Issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "IssueCategory",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district": {
+          "name": "district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subregion": {
+          "name": "subregion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locationSource": {
+          "name": "locationSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "photoTakenAt": {
+          "name": "photoTakenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photoTakenAtSource": {
+          "name": "photoTakenAtSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cityRefNumber": {
+          "name": "cityRefNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedById": {
+          "name": "claimedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Issue_latitude_longitude_idx": {
+          "name": "Issue_latitude_longitude_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_status_idx": {
+          "name": "Issue_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_category_idx": {
+          "name": "Issue_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_createdAt_idx": {
+          "name": "Issue_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Issue_userId_user_id_fk": {
+          "name": "Issue_userId_user_id_fk",
+          "tableFrom": "Issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrgMembership": {
+      "name": "OrgMembership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrgRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORG_MEMBER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrgMembership_userId_organizationId_key": {
+          "name": "OrgMembership_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_organizationId_idx": {
+          "name": "OrgMembership_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_userId_idx": {
+          "name": "OrgMembership_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrgMembership_userId_user_id_fk": {
+          "name": "OrgMembership_userId_user_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrgMembership_organizationId_Organization_id_fk": {
+          "name": "OrgMembership_organizationId_Organization_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "OrgType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrgStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "OrgTier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categoryScope": {
+          "name": "categoryScope",
+          "type": "IssueCategory[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "boundarySource": {
+          "name": "boundarySource",
+          "type": "BoundarySource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundaryRef": {
+          "name": "boundaryRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundarySyncedAt": {
+          "name": "boundarySyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geofence": {
+          "name": "geofence",
+          "type": "geography(MultiPolygon,4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Organization_status_idx": {
+          "name": "Organization_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_geofence_idx": {
+          "name": "Organization_geofence_idx",
+          "columns": [
+            {
+              "expression": "geofence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_key": {
+          "name": "Organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEntry": {
+      "name": "TimelineEntry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "TimelineEntry_issueId_idx": {
+          "name": "TimelineEntry_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEntry_createdAt_idx": {
+          "name": "TimelineEntry_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEntry_issueId_Issue_id_fk": {
+          "name": "TimelineEntry_issueId_Issue_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TimelineEntry_userId_user_id_fk": {
+          "name": "TimelineEntry_userId_user_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Upvote": {
+      "name": "Upvote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Upvote_issueId_userId_key": {
+          "name": "Upvote_issueId_userId_key",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Upvote_issueId_idx": {
+          "name": "Upvote_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Upvote_issueId_Issue_id_fk": {
+          "name": "Upvote_issueId_Issue_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Upvote_userId_user_id_fk": {
+          "name": "Upvote_userId_user_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileImage": {
+          "name": "profileImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_key": {
+          "name": "user_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.BoundarySource": {
+      "name": "BoundarySource",
+      "schema": "public",
+      "values": [
+        "OFFICIAL",
+        "UPLOADED",
+        "FREEHAND"
+      ]
+    },
+    "public.EventStatus": {
+      "name": "EventStatus",
+      "schema": "public",
+      "values": [
+        "PLANNED",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.IssueCategory": {
+      "name": "IssueCategory",
+      "schema": "public",
+      "values": [
+        "POTHOLE",
+        "STREETLIGHT",
+        "GRAFFITI",
+        "ILLEGAL_DUMPING",
+        "BROKEN_SIDEWALK",
+        "TRAFFIC_SIGNAL",
+        "OTHER"
+      ]
+    },
+    "public.IssueStatus": {
+      "name": "IssueStatus",
+      "schema": "public",
+      "values": [
+        "REPORTED",
+        "ACKNOWLEDGED",
+        "IN_PROGRESS",
+        "RESOLVED",
+        "CLOSED",
+        "COMMUNITY_RESOLVED"
+      ]
+    },
+    "public.OrgRole": {
+      "name": "OrgRole",
+      "schema": "public",
+      "values": [
+        "ORG_ADMIN",
+        "ORG_MEMBER"
+      ]
+    },
+    "public.OrgStatus": {
+      "name": "OrgStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACTIVE",
+        "SUSPENDED"
+      ]
+    },
+    "public.OrgTier": {
+      "name": "OrgTier",
+      "schema": "public",
+      "values": [
+        "STARTER",
+        "GROWTH",
+        "FULLSCALE"
+      ]
+    },
+    "public.OrgType": {
+      "name": "OrgType",
+      "schema": "public",
+      "values": [
+        "WARD_OFFICE",
+        "CID",
+        "BID",
+        "SBD",
+        "CDC",
+        "NONPROFIT",
+        "CITY_DEPARTMENT",
+        "OTHER"
+      ]
+    },
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": [
+        "REPORTER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/0004_snapshot.json
+++ b/backend/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1476 @@
+{
+  "id": "54e18ff7-6360-4ca3-afa7-26885cd86d71",
+  "prevId": "372ef1c1-4ee3-4674-b29c-a67185266abc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.EventRsvp": {
+      "name": "EventRsvp",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "EventRsvp_eventId_userId_key": {
+          "name": "EventRsvp_eventId_userId_key",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "EventRsvp_eventId_idx": {
+          "name": "EventRsvp_eventId_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "EventRsvp_eventId_Event_id_fk": {
+          "name": "EventRsvp_eventId_Event_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "Event",
+          "columnsFrom": [
+            "eventId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "EventRsvp_userId_user_id_fk": {
+          "name": "EventRsvp_userId_user_id_fk",
+          "tableFrom": "EventRsvp",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Event": {
+      "name": "Event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "EventStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PLANNED'"
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizerId": {
+          "name": "organizerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Event_startTime_idx": {
+          "name": "Event_startTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Event_status_idx": {
+          "name": "Event_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Event_organizerId_user_id_fk": {
+          "name": "Event_organizerId_user_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "user",
+          "columnsFrom": [
+            "organizerId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "Event_issueId_Issue_id_fk": {
+          "name": "Event_issueId_Issue_id_fk",
+          "tableFrom": "Event",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Issue": {
+      "name": "Issue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "IssueCategory",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district": {
+          "name": "district",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subregion": {
+          "name": "subregion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locationSource": {
+          "name": "locationSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "photoTakenAt": {
+          "name": "photoTakenAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photoTakenAtSource": {
+          "name": "photoTakenAtSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'device'"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cityRefNumber": {
+          "name": "cityRefNumber",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimedById": {
+          "name": "claimedById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Issue_latitude_longitude_idx": {
+          "name": "Issue_latitude_longitude_idx",
+          "columns": [
+            {
+              "expression": "latitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "longitude",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_status_idx": {
+          "name": "Issue_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_category_idx": {
+          "name": "Issue_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Issue_createdAt_idx": {
+          "name": "Issue_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Issue_userId_user_id_fk": {
+          "name": "Issue_userId_user_id_fk",
+          "tableFrom": "Issue",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrgMembership": {
+      "name": "OrgMembership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "OrgRole",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ORG_MEMBER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrgMembership_userId_organizationId_key": {
+          "name": "OrgMembership_userId_organizationId_key",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_organizationId_idx": {
+          "name": "OrgMembership_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrgMembership_userId_idx": {
+          "name": "OrgMembership_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "OrgMembership_userId_user_id_fk": {
+          "name": "OrgMembership_userId_user_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "OrgMembership_organizationId_Organization_id_fk": {
+          "name": "OrgMembership_organizationId_Organization_id_fk",
+          "tableFrom": "OrgMembership",
+          "tableTo": "Organization",
+          "columnsFrom": [
+            "organizationId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "OrgType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OrgStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "tier": {
+          "name": "tier",
+          "type": "OrgTier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "categoryScope": {
+          "name": "categoryScope",
+          "type": "IssueCategory[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "boundarySource": {
+          "name": "boundarySource",
+          "type": "BoundarySource",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundaryRef": {
+          "name": "boundaryRef",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "boundarySyncedAt": {
+          "name": "boundarySyncedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geofence": {
+          "name": "geofence",
+          "type": "geography(MultiPolygon,4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profileImage": {
+          "name": "profileImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Organization_status_idx": {
+          "name": "Organization_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_geofence_idx": {
+          "name": "Organization_geofence_idx",
+          "columns": [
+            {
+              "expression": "geofence",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gist",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Organization_slug_key": {
+          "name": "Organization_slug_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_key": {
+          "name": "session_token_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimelineEntry": {
+      "name": "TimelineEntry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "IssueStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTED'"
+        },
+        "images": {
+          "name": "images",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {
+        "TimelineEntry_issueId_idx": {
+          "name": "TimelineEntry_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimelineEntry_createdAt_idx": {
+          "name": "TimelineEntry_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimelineEntry_issueId_Issue_id_fk": {
+          "name": "TimelineEntry_issueId_Issue_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "TimelineEntry_userId_user_id_fk": {
+          "name": "TimelineEntry_userId_user_id_fk",
+          "tableFrom": "TimelineEntry",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Upvote": {
+      "name": "Upvote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "issueId": {
+          "name": "issueId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Upvote_issueId_userId_key": {
+          "name": "Upvote_issueId_userId_key",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Upvote_issueId_idx": {
+          "name": "Upvote_issueId_idx",
+          "columns": [
+            {
+              "expression": "issueId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Upvote_issueId_Issue_id_fk": {
+          "name": "Upvote_issueId_Issue_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "Issue",
+          "columnsFrom": [
+            "issueId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "Upvote_userId_user_id_fk": {
+          "name": "Upvote_userId_user_id_fk",
+          "tableFrom": "Upvote",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileImage": {
+          "name": "profileImage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "Role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REPORTER'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "user_email_idx": {
+          "name": "user_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_key": {
+          "name": "user_email_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp (3)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.BoundarySource": {
+      "name": "BoundarySource",
+      "schema": "public",
+      "values": [
+        "OFFICIAL",
+        "UPLOADED",
+        "FREEHAND"
+      ]
+    },
+    "public.EventStatus": {
+      "name": "EventStatus",
+      "schema": "public",
+      "values": [
+        "PLANNED",
+        "IN_PROGRESS",
+        "COMPLETED",
+        "CANCELLED"
+      ]
+    },
+    "public.IssueCategory": {
+      "name": "IssueCategory",
+      "schema": "public",
+      "values": [
+        "POTHOLE",
+        "STREETLIGHT",
+        "GRAFFITI",
+        "ILLEGAL_DUMPING",
+        "BROKEN_SIDEWALK",
+        "TRAFFIC_SIGNAL",
+        "OTHER"
+      ]
+    },
+    "public.IssueStatus": {
+      "name": "IssueStatus",
+      "schema": "public",
+      "values": [
+        "REPORTED",
+        "ACKNOWLEDGED",
+        "IN_PROGRESS",
+        "RESOLVED",
+        "CLOSED",
+        "COMMUNITY_RESOLVED"
+      ]
+    },
+    "public.OrgRole": {
+      "name": "OrgRole",
+      "schema": "public",
+      "values": [
+        "ORG_ADMIN",
+        "ORG_MEMBER"
+      ]
+    },
+    "public.OrgStatus": {
+      "name": "OrgStatus",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "ACTIVE",
+        "SUSPENDED"
+      ]
+    },
+    "public.OrgTier": {
+      "name": "OrgTier",
+      "schema": "public",
+      "values": [
+        "STARTER",
+        "GROWTH",
+        "FULLSCALE"
+      ]
+    },
+    "public.OrgType": {
+      "name": "OrgType",
+      "schema": "public",
+      "values": [
+        "WARD_OFFICE",
+        "CID",
+        "BID",
+        "SBD",
+        "CDC",
+        "NONPROFIT",
+        "CITY_DEPARTMENT",
+        "OTHER"
+      ]
+    },
+    "public.Role": {
+      "name": "Role",
+      "schema": "public",
+      "values": [
+        "REPORTER",
+        "ADMIN"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786149646862,
       "tag": "0003_lumpy_franklin_storm",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1786224258199,
+      "tag": "0004_married_warlock",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -8,6 +8,27 @@
       "when": 1785985857772,
       "tag": "0000_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1786143790040,
+      "tag": "0001_wonderful_rumiko_fujikawa",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1786149332383,
+      "tag": "0002_melodic_stellaris",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1786149646862,
+      "tag": "0003_lumpy_franklin_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/config/permissions.ts
+++ b/backend/src/config/permissions.ts
@@ -4,6 +4,9 @@ import { Role } from "../db/schema";
 const reporter_perms = ['create:issue', 'create:upvote',
     'read:upvote', 'delete:upvote', 'create:upload_signature'];
 
+const responder_perms = [...reporter_perms, 'update:issue_status',
+    'create:timeline_entry', 'update:claim_issue'
+]
 // Admins can do everything a reporter can, plus admin-only actions.
 export const rolePermissions: Record<Role, string[]> = {
     REPORTER: reporter_perms,

--- a/backend/src/config/permissions.ts
+++ b/backend/src/config/permissions.ts
@@ -4,9 +4,6 @@ import { Role } from "../db/schema";
 const reporter_perms = ['create:issue', 'create:upvote',
     'read:upvote', 'delete:upvote', 'create:upload_signature'];
 
-const responder_perms = [...reporter_perms, 'update:issue_status',
-    'create:timeline_entry', 'update:claim_issue'
-]
 // Admins can do everything a reporter can, plus admin-only actions.
 export const rolePermissions: Record<Role, string[]> = {
     REPORTER: reporter_perms,

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -37,7 +37,6 @@ export class AuthController {
 
   async getUserById(req: Request, res: Response, next: NextFunction) {
     try {
-      console.log(req.params.userId)
       const user = await authService.getUserById(String(req.params.userId));
       res.json(user);
     } catch (error: any) {

--- a/backend/src/controllers/issue.controller.ts
+++ b/backend/src/controllers/issue.controller.ts
@@ -5,10 +5,11 @@ import { IssueRepository } from '../repositories/issue.repository';
 import { PostUpdateDTO } from '@civickit/shared';
 import { TimelineService } from '../services/timeline.service';
 import { TimelineRepository } from '../repositories/timeline.repository';
+import { AuthRepository } from '../repositories/auth.repository';
 
 const issueRepository = new IssueRepository();
 const issueService = new IssueService(issueRepository);
-const timelineService = new TimelineService(new TimelineRepository());
+const timelineService = new TimelineService(new TimelineRepository(), new AuthRepository);
 
 // Parses an optional `limit` query param, clamped to [1, 200], defaulting to 100.
 function parseLimit(raw: unknown): number {

--- a/backend/src/controllers/issue.controller.ts
+++ b/backend/src/controllers/issue.controller.ts
@@ -125,4 +125,15 @@ export class IssueController {
       next(error);
     }
   }
+
+  // claim issue
+  async claimIssue(req: Request, res: Response, next: NextFunction) {
+    try {
+      const userId = req.userId!
+      const issue = await issueService.claimIssue(String(req.params.issueId), userId);
+      res.json(issue);
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/backend/src/controllers/issue.controller.ts
+++ b/backend/src/controllers/issue.controller.ts
@@ -136,4 +136,14 @@ export class IssueController {
       next(error);
     }
   }
+
+  //release issue
+  async releaseIssue(req: Request, res: Response, next: NextFunction) {
+    try {
+      const issue = await issueService.releaseIssue(String(req.params.issueId));
+      res.json(issue);
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/backend/src/controllers/org.controller.ts
+++ b/backend/src/controllers/org.controller.ts
@@ -1,0 +1,86 @@
+// backend/src/controllers/organization.controller.ts
+import { Request, Response, NextFunction } from 'express';
+import { IssueService } from '../services/issue.service';
+import { IssueRepository } from '../repositories/issue.repository';
+import { PostUpdateDTO } from '@civickit/shared';
+import { TimelineService } from '../services/timeline.service';
+import { TimelineRepository } from '../repositories/timeline.repository';
+import { OrgRepository } from '../repositories/org.repository';
+import { MembershipRepository } from '../repositories/membership.repository';
+import { OrgService } from '../services/org.service';
+import { MembershipService } from '../services/membership.service';
+
+const orgRepository = new OrgRepository();
+const orgService = new OrgService(orgRepository);
+
+const membershipRepository = new MembershipRepository()
+const membershipService = new MembershipService(membershipRepository)
+
+export class OrgController {
+  async createOrg(req: Request, res: Response, next: NextFunction) {
+    try {
+      const org = await orgService.createOrg(
+        {
+          ...req.body,
+          //TODO: add in geofence
+        }, req.userId!);
+      res.status(201).json(org);
+
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async createMembership(req: Request, res: Response, next: NextFunction) {
+    try {
+
+      const membership = await membershipService.createMembership(
+        {
+          ...req.body,
+        });
+      res.status(201).json(membership);
+
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getOrgByOrgId(req: Request, res: Response, next: NextFunction) {
+    try {
+      const org = await orgService.getOrgById(String(req.params.orgId));
+      res.json(org);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getOrgByUserId(req: Request, res: Response, next: NextFunction) {
+    try {
+      const org = await orgService.getOrgByUserId(String(req.params.userId));
+      res.json(org);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getMembershipsByOrgId(req: Request, res: Response, next: NextFunction) {
+    try {
+      const members = await membershipService.getOrgMemberships(String(req.params.orgId));
+      res.json(members);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async getMembershipByUserId(req: Request, res: Response, next: NextFunction) {
+    try {
+      const org = await membershipService.getMembershipByUserId(String(req.params.userId));
+      res.json(org);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+
+
+}

--- a/backend/src/controllers/timeline.controller.ts
+++ b/backend/src/controllers/timeline.controller.ts
@@ -5,9 +5,9 @@ import { TimelineRepository } from '../repositories/timeline.repository';
 import { IssueController } from './issue.controller';
 import { IssueService } from '../services/issue.service';
 import { IssueRepository } from '../repositories/issue.repository';
+import { AuthRepository } from '../repositories/auth.repository';
 
-
-const timelineService = new TimelineService(new TimelineRepository());
+const timelineService = new TimelineService(new TimelineRepository(), new AuthRepository);
 const issueService = new IssueService(new IssueRepository);
 
 export class TimelineController {

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -163,6 +163,7 @@ export const issues = pgTable(
       .notNull()
       .references(() => users.id, { onDelete: 'restrict', onUpdate: 'cascade' }),
     cityRefNumber: text('cityRefNumber'),
+    claimedById: text('claimedById')
   },
   (table) => [
     index('Issue_latitude_longitude_idx').on(table.latitude, table.longitude),

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -116,7 +116,7 @@ const updatedAt = () =>
  * loudly on the next db:reset -- but if you ever regenerate a migration that
  * recreates or alters this column, check for it.
  */
-const geography = customType<{ data: string; driverData: string }>({
+export const geography = customType<{ data: string; driverData: string }>({
   dataType: () => 'geography(MultiPolygon,4326)',
 });
 
@@ -340,6 +340,7 @@ export const organizations = pgTable(
     geofence: geography('geofence'),
     createdAt: timestamp3('createdAt').notNull().defaultNow(),
     updatedAt: updatedAt(),
+    profileImage: text('profileImage'),
   },
   (table) => [
     index('Organization_status_idx').on(table.status),

--- a/backend/src/middleware/__tests__/authorize.middleware.test.ts
+++ b/backend/src/middleware/__tests__/authorize.middleware.test.ts
@@ -36,6 +36,7 @@ describe('requirePermission', () => {
     await requirePermission('update:issue_status')(req, res, next);
 
     const error = errorPassedToNext();
+    console.log("!!!!!", error)
     expect(error).toBeInstanceOf(AppError);
     expect(error.statusCode).toBe(403);
   });

--- a/backend/src/middleware/authorize.middleware.ts
+++ b/backend/src/middleware/authorize.middleware.ts
@@ -2,12 +2,12 @@ import { Request, Response, NextFunction } from "express";
 import { rolePermissions } from "../config/permissions";
 import { AuthRepository } from "../repositories/auth.repository";
 import { AppError, UnauthorizedError } from "../utils/errors";
-import { OrgMembershipRepository } from "../repositories/orgMembership.repository";
+import { MembershipRepository } from "../repositories/membership.repository";
 import { IssueRepository } from "../repositories/issue.repository";
 import { OrgRepository } from "../repositories/org.repository";
 
 const authRepo = new AuthRepository();
-const orgMembershipRepo = new OrgMembershipRepository();
+const orgMembershipRepo = new MembershipRepository();
 const issueRepo = new IssueRepository();
 const orgRepo = new OrgRepository();
 
@@ -18,9 +18,6 @@ function requirePermission(permission: string) {
             if (!userId) {
                 throw new UnauthorizedError("Not authenticated");
             }
-
-            console.log(req)
-
             // Load the role fresh from the DB every request → revocation is instant.
             const user = await authRepo.findById(userId);
             if (!user) {
@@ -41,7 +38,7 @@ function requirePermission(permission: string) {
                     }
 
                     //TODO: check that issue is within org's service area
-                } else if (permission == "create:timeline_entry") {
+                } else if (permission == "create:timeline_entry" || permission == "update:release_issue") {
                     if (!req.params.issueId) {
                         throw new UnauthorizedError("No issueId provided");
                     }
@@ -64,7 +61,7 @@ function requirePermission(permission: string) {
 
                     const orgClaimedBy = await orgMembershipRepo.findByUser(claimedById)
                     if (!orgClaimedBy) {
-                        throw new UnauthorizedError("Isse not claimed by any organization");
+                        throw new UnauthorizedError("Issue not claimed by any organization");
                     }
 
                     if (orgClaimedBy.organizationId != orgMembership.organizationId) {

--- a/backend/src/middleware/authorize.middleware.ts
+++ b/backend/src/middleware/authorize.middleware.ts
@@ -38,16 +38,17 @@ function requirePermission(permission: string) {
                     }
 
                     //TODO: check that issue is within org's service area
-                } else if (permission == "create:timeline_entry" || permission == "update:release_issue") {
+                } else if (permission == "create:timeline_entry" ||
+                    permission == "update:release_issue" ||
+                    permission == 'update:issue_status') {
 
 
-                    if (!req.params.issueId) {
-                        throw new UnauthorizedError("No issueId provided");
+                    let orgMembership = undefined
+                    try {
+                        orgMembership = await orgMembershipRepo.findByUser(userId)
+                    } catch (error) {
+                        throw new AppError("User not in any organization", 403);
                     }
-
-                    const orgMembership = await orgMembershipRepo.findByUser(userId)
-
-                    console.log("$$$$$", permission, req.params.issueId, userId)
 
                     if (!orgMembership) {
                         throw new AppError("User not in any organization", 403);
@@ -58,15 +59,19 @@ function requirePermission(permission: string) {
                         throw new AppError("Forbidden", 403);
                     }
 
+                    if (!req.params || !req.params.issueId) {
+                        throw new AppError("No issueId provided", 400);
+                    }
+
                     const issue = await issueRepo.findById(String(req.params.issueId))
                     const claimedById = issue?.claimedById
                     if (!claimedById) {
-                        throw new UnauthorizedError("Issue not claimed");
+                        throw new AppError("Issue not claimed", 400);
                     }
 
                     const orgClaimedBy = await orgMembershipRepo.findByUser(claimedById)
                     if (!orgClaimedBy) {
-                        throw new UnauthorizedError("Issue not claimed by any organization");
+                        throw new AppError("Issue not claimed by any organization", 400);
                     }
 
                     if (orgClaimedBy.organizationId != orgMembership.organizationId) {

--- a/backend/src/middleware/authorize.middleware.ts
+++ b/backend/src/middleware/authorize.middleware.ts
@@ -2,8 +2,14 @@ import { Request, Response, NextFunction } from "express";
 import { rolePermissions } from "../config/permissions";
 import { AuthRepository } from "../repositories/auth.repository";
 import { AppError, UnauthorizedError } from "../utils/errors";
+import { OrgMembershipRepository } from "../repositories/orgMembership.repository";
+import { IssueRepository } from "../repositories/issue.repository";
+import { OrgRepository } from "../repositories/org.repository";
 
 const authRepo = new AuthRepository();
+const orgMembershipRepo = new OrgMembershipRepository();
+const issueRepo = new IssueRepository();
+const orgRepo = new OrgRepository();
 
 function requirePermission(permission: string) {
     return async (req: Request, res: Response, next: NextFunction) => {
@@ -13,6 +19,8 @@ function requirePermission(permission: string) {
                 throw new UnauthorizedError("Not authenticated");
             }
 
+            console.log(req)
+
             // Load the role fresh from the DB every request → revocation is instant.
             const user = await authRepo.findById(userId);
             if (!user) {
@@ -21,7 +29,50 @@ function requirePermission(permission: string) {
 
             const allowed = rolePermissions[user.role];
             if (!allowed || !allowed.includes(permission)) {
-                throw new AppError("Forbidden", 403);
+                if (permission == "update:claim_issue") {
+                    const orgMembership = await orgMembershipRepo.findByUser(userId)
+                    if (!orgMembership) {
+                        throw new UnauthorizedError("User not in an organization");
+                    }
+                    if (orgMembership.role != "ORG_MEMBER" &&
+                        orgMembership.role != "ORG_ADMIN"
+                    ) {
+                        throw new AppError("Forbidden", 403);
+                    }
+
+                    //TODO: check that issue is within org's service area
+                } else if (permission == "create:timeline_entry") {
+                    if (!req.params.issueId) {
+                        throw new UnauthorizedError("No issueId provided");
+                    }
+
+                    const orgMembership = await orgMembershipRepo.findByUser(userId)
+                    if (!orgMembership) {
+                        throw new UnauthorizedError("User not in any organization");
+                    }
+                    if (orgMembership.role != "ORG_MEMBER" &&
+                        orgMembership.role != "ORG_ADMIN"
+                    ) {
+                        throw new AppError("Forbidden", 403);
+                    }
+
+                    const issue = await issueRepo.findById(String(req.params.issueId))
+                    const claimedById = issue?.claimedById
+                    if (!claimedById) {
+                        throw new UnauthorizedError("Issue not claimed");
+                    }
+
+                    const orgClaimedBy = await orgMembershipRepo.findByUser(claimedById)
+                    if (!orgClaimedBy) {
+                        throw new UnauthorizedError("Isse not claimed by any organization");
+                    }
+
+                    if (orgClaimedBy.organizationId != orgMembership.organizationId) {
+                        throw new UnauthorizedError("User not in selected issue's organization");
+                    }
+                } else {
+                    throw new AppError("Forbidden", 403);
+                }
             }
 
             next();

--- a/backend/src/middleware/authorize.middleware.ts
+++ b/backend/src/middleware/authorize.middleware.ts
@@ -29,7 +29,7 @@ function requirePermission(permission: string) {
                 if (permission == "update:claim_issue") {
                     const orgMembership = await orgMembershipRepo.findByUser(userId)
                     if (!orgMembership) {
-                        throw new UnauthorizedError("User not in an organization");
+                        throw new AppError("User not in an organization", 403);
                     }
                     if (orgMembership.role != "ORG_MEMBER" &&
                         orgMembership.role != "ORG_ADMIN"
@@ -39,13 +39,18 @@ function requirePermission(permission: string) {
 
                     //TODO: check that issue is within org's service area
                 } else if (permission == "create:timeline_entry" || permission == "update:release_issue") {
+
+
                     if (!req.params.issueId) {
                         throw new UnauthorizedError("No issueId provided");
                     }
 
                     const orgMembership = await orgMembershipRepo.findByUser(userId)
+
+                    console.log("$$$$$", permission, req.params.issueId, userId)
+
                     if (!orgMembership) {
-                        throw new UnauthorizedError("User not in any organization");
+                        throw new AppError("User not in any organization", 403);
                     }
                     if (orgMembership.role != "ORG_MEMBER" &&
                         orgMembership.role != "ORG_ADMIN"
@@ -65,7 +70,7 @@ function requirePermission(permission: string) {
                     }
 
                     if (orgClaimedBy.organizationId != orgMembership.organizationId) {
-                        throw new UnauthorizedError("User not in selected issue's organization");
+                        throw new AppError("User not in selected issue's organization", 403);
                     }
                 } else {
                     throw new AppError("Forbidden", 403);

--- a/backend/src/repositories/__tests__/integration/login.repository.integration.test.ts
+++ b/backend/src/repositories/__tests__/integration/login.repository.integration.test.ts
@@ -20,6 +20,7 @@ describe('LoginRepository', () => {
         passwordHash: 'not-a-real-hash',
         profileImage: null,
         createdAt: expect.any(Date),
+        role: "REPORTER"
       });
     });
 
@@ -35,6 +36,7 @@ describe('LoginRepository', () => {
         'name',
         'passwordHash',
         'profileImage',
+        'role'
       ]);
     });
 

--- a/backend/src/repositories/issue.repository.ts
+++ b/backend/src/repositories/issue.repository.ts
@@ -140,4 +140,18 @@ export class IssueRepository {
 
     return updated;
   }
+
+  async claimIssue(id: string, data: Partial<{ claimedById: string }>) {
+    const [updated] = await db
+      .update(issues)
+      .set(data)
+      .where(eq(issues.id, id))
+      .returning();
+
+    if (!updated) {
+      throw new RecordNotFoundError('Issue not found');
+    }
+
+    return updated;
+  }
 }

--- a/backend/src/repositories/issue.repository.ts
+++ b/backend/src/repositories/issue.repository.ts
@@ -154,4 +154,18 @@ export class IssueRepository {
 
     return updated;
   }
+
+  async releaseIssue(id: string) {
+    const [updated] = await db
+      .update(issues)
+      .set({ claimedById: null })
+      .where(eq(issues.id, id))
+      .returning();
+
+    if (!updated) {
+      throw new RecordNotFoundError('Issue not found');
+    }
+
+    return updated;
+  }
 }

--- a/backend/src/repositories/login.repository.ts
+++ b/backend/src/repositories/login.repository.ts
@@ -15,6 +15,7 @@ export class LoginRepository {
           passwordHash: users.passwordHash,
           profileImage: users.profileImage,
           createdAt: users.createdAt,
+          role: users.role
         })
         .from(users)
         .where(eq(users.email, email))

--- a/backend/src/repositories/membership.repository.ts
+++ b/backend/src/repositories/membership.repository.ts
@@ -30,7 +30,7 @@ export class MembershipRepository {
 
   async findByUser(id: string) {
     return first(
-      await db.select().from(orgMemberships).where(eq(orgMemberships.userId, id))
+      await db.select().from(orgMemberships).where(eq(orgMemberships.userId, id)).limit(1),
     )
 
   }

--- a/backend/src/repositories/membership.repository.ts
+++ b/backend/src/repositories/membership.repository.ts
@@ -8,7 +8,7 @@ import { Issue, orgMemberships, upvotes, users } from '../db/schema';
 import { OrgMembershipDTO } from '@civickit/shared/src/types/api';
 
 
-export class OrgMembershipRepository {
+export class MembershipRepository {
 
   async create(data: OrgMembershipDTO) {
     const [inserted] = await db

--- a/backend/src/repositories/org.repository.ts
+++ b/backend/src/repositories/org.repository.ts
@@ -1,9 +1,11 @@
 // backend/src/repositories/org.repository.ts
 
 import { IssueCategory } from '@civickit/shared';
-import { sql } from 'drizzle-orm';
-import db from '../db';
+import { eq, getTableColumns, sql } from 'drizzle-orm';
+import db, { first } from '../db';
 import { Issue, issues, organizations } from '../db/schema';
+import { CreateOrgDTO } from '@civickit/shared/src/types/api';
+import { MembershipRepository } from './membership.repository';
 
 /**
  * A row from findOrgsForIssue. Raw SQL, so the shape is asserted rather than
@@ -16,7 +18,41 @@ export interface OrgMatch {
   categoryScope: string[];
 }
 
+const membershipRepository = new MembershipRepository();
+
 export class OrgRepository {
+
+  async create(data: CreateOrgDTO & { adminId: string }) {
+    const [inserted] = await db
+      .insert(organizations)
+      .values({
+        name: data.name,
+        slug: data.slug,
+        type: data.type,
+        status: data.status,
+        tier: data.tier,
+        categoryScope: data.categoryScope,
+        boundaryRef: data.boundaryRef,
+        boundarySource: data.boundarySource,
+        boundarySyncedAt: data.boundarySyncedAt,
+        //TODO: add in geofence
+      })
+      .returning({ id: organizations.id });
+
+    const membership = membershipRepository.create({
+      userId: data.adminId,
+      organizationId: inserted.id,
+      role: "ORG_ADMIN"
+    })
+
+    // Re-read so create returns the same shape as findById.
+    return (await this.findById(inserted.id))!;
+  }
+
+  async findById(id: string) {
+    return first(await db.select().from(organizations).where(eq(organizations.id, id)).limit(1));
+  }
+
   // Orgs whose geofence contains the issue's point AND whose categoryScope
   // includes the issue's category AND are ACTIVE.
   //

--- a/backend/src/repositories/orgMembership.repository.ts
+++ b/backend/src/repositories/orgMembership.repository.ts
@@ -1,0 +1,40 @@
+// backend/src/repositories/issue.repository.ts
+
+import { CreateIssueDTO, IssueStatus } from '@civickit/shared';
+import { and, desc, eq, exists, getTableColumns, sql } from 'drizzle-orm';
+import db, { first } from '../db';
+import { RecordNotFoundError } from '../db/errors';
+import { Issue, orgMemberships, upvotes, users } from '../db/schema';
+import { OrgMembershipDTO } from '@civickit/shared/src/types/api';
+
+
+export class OrgMembershipRepository {
+
+  async create(data: OrgMembershipDTO) {
+    const [inserted] = await db
+      .insert(orgMemberships)
+      .values({
+        userId: data.userId,
+        organizationId: data.organizationId,
+        role: data.role,
+      })
+      .returning({ id: orgMemberships.id });
+
+    // Re-read so create returns the same shape as findById.
+    return (await this.findById(inserted.id))!;
+  }
+
+  async findById(id: string) {
+    return db.select().from(orgMemberships).where(eq(orgMemberships.id, id));
+  }
+
+  async findByUser(id: string) {
+    return first(
+      await db.select().from(orgMemberships).where(eq(orgMemberships.userId, id))
+    )
+
+  }
+  async findByOrganization(id: string) {
+    return db.select().from(orgMemberships).where(eq(orgMemberships.organizationId, id));
+  }
+}

--- a/backend/src/repositories/timeline.repository.ts
+++ b/backend/src/repositories/timeline.repository.ts
@@ -28,7 +28,7 @@ export class TimelineRepository {
   }
 
   async findByIssue(id: string) {
-    return db.select().from(timelineEntries).where(eq(timelineEntries.issueId, id));
+    return await db.select().from(timelineEntries).where(eq(timelineEntries.issueId, id));
   }
 
   async findByUser(id: string) {

--- a/backend/src/repositories/timeline.repository.ts
+++ b/backend/src/repositories/timeline.repository.ts
@@ -32,6 +32,6 @@ export class TimelineRepository {
   }
 
   async findByUser(id: string) {
-    return db.select().from(timelineEntries).where(eq(timelineEntries.userId, id));
+    return await db.select().from(timelineEntries).where(eq(timelineEntries.userId, id));
   }
 }

--- a/backend/src/routes/__tests__/issue.routes.authz.test.ts
+++ b/backend/src/routes/__tests__/issue.routes.authz.test.ts
@@ -59,8 +59,6 @@ describe('issue status authorization', () => {
 
       const response = await route.send().send({ status: 'RESOLVED' });
 
-      console.log("$$$$$$", response)
-
       expect(response.status).toBe(403);
       expect(updateStatus).not.toHaveBeenCalled();
     });

--- a/backend/src/routes/__tests__/issue.routes.authz.test.ts
+++ b/backend/src/routes/__tests__/issue.routes.authz.test.ts
@@ -59,6 +59,8 @@ describe('issue status authorization', () => {
 
       const response = await route.send().send({ status: 'RESOLVED' });
 
+      console.log("$$$$$$", response)
+
       expect(response.status).toBe(403);
       expect(updateStatus).not.toHaveBeenCalled();
     });

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -18,5 +18,8 @@ router.use(limiter)
 router.post("/register", authController.register.bind(authController));
 router.get('/user', authMiddleware, authController.getCurrentUser);
 router.get('/:userId/user', authMiddleware, authController.getUserById)
+router.get('/user', authMiddleware, authController.getCurrentUser);
+router.get('/:userId/user', authMiddleware, authController.getUserById)
+
 
 export default router;

--- a/backend/src/routes/issue.routes.ts
+++ b/backend/src/routes/issue.routes.ts
@@ -33,5 +33,7 @@ router.post('/:issueId/update', authMiddleware, requirePermission('update:issue_
 router.get('/:issueId/updates', authMiddleware, timelineController.getIssueUpdates)
 router.get('/:userId/userUpdates', authMiddleware, timelineController.getUserUpdates)
 
+//claiming an issue
+router.post('/:issueId/claim', authMiddleware, requirePermission('update:claim_issue'), issueController.claimIssue)
 
 export default router;

--- a/backend/src/routes/issue.routes.ts
+++ b/backend/src/routes/issue.routes.ts
@@ -29,11 +29,11 @@ router.patch('/:issueId/status', authMiddleware, requirePermission('update:issue
 
 // timeline functionality
 // postUpdate changes the issue status, so it needs the same gate as PATCH /status.
-router.post('/:issueId/update', authMiddleware, requirePermission('update:issue_status'), timelineController.postUpdate);
+router.post('/:issueId/update', authMiddleware, requirePermission('create:timeline_entry'), timelineController.postUpdate);
 router.get('/:issueId/updates', authMiddleware, timelineController.getIssueUpdates)
 router.get('/:userId/userUpdates', authMiddleware, timelineController.getUserUpdates)
 
 //claiming an issue
 router.post('/:issueId/claim', authMiddleware, requirePermission('update:claim_issue'), issueController.claimIssue)
-
+router.post('/:issueId/release', authMiddleware, requirePermission('update:release_issue'), issueController.releaseIssue)
 export default router;

--- a/backend/src/routes/org.routes.ts
+++ b/backend/src/routes/org.routes.ts
@@ -1,0 +1,22 @@
+// backend/src/routes/org.routes.ts
+import { Router } from 'express';
+import { authMiddleware } from '../middleware/auth.middleware';
+import { requirePermission } from '../middleware/authorize.middleware';
+import { OrgController } from '../controllers/org.controller';
+
+const router = Router();
+const orgController = new OrgController();
+
+router.post('/', authMiddleware, orgController.createOrg)
+router.post('/createMembership', authMiddleware, orgController.createMembership);
+
+router.get('/:orgId/getOrgById', authMiddleware, orgController.getOrgByOrgId)
+router.get('/:orgId/getMembershipsbyOrgId', authMiddleware, orgController.getMembershipsByOrgId);
+
+router.get('/:userId/getOrgByUserId', authMiddleware, orgController.getOrgByUserId);
+router.get('/:userId/getMembershipByUserId', authMiddleware, orgController.getMembershipByUserId);
+
+
+
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import issueRoutes from './routes/issue.routes';
 import authRoutes from "./routes/auth.routes";
 import uploadRoutes from './routes/upload.routes';
 import loginRoutes from './routes/login.routes';
+import orgRoutes from './routes/org.routes'
 import RateLimit from 'express-rate-limit';
 import { errorHandler } from './middleware/error.middleware';
 import { requestLogger } from './middleware/logger.middleware';
@@ -61,6 +62,7 @@ app.use(limiter)
 // Routes
 // TODO: Add routes
 app.use('/api/issues', issueRoutes);
+app.use('/api/organizations', orgRoutes)
 app.use('/api/auth/login', loginRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/upload', uploadRoutes);

--- a/backend/src/services/__tests__/unit/issue.service.test.ts
+++ b/backend/src/services/__tests__/unit/issue.service.test.ts
@@ -194,7 +194,19 @@ describe('IssueService', () => {
 
   describe('getIssueById', () => {
     it('should return issue if found', async () => {
-      const mockIssue = { id: '123' };
+      const mockIssue = {
+        id: '123',
+        claimedByOrg: {
+          id: undefined,
+          name: undefined,
+          profileImage: undefined,
+        },
+        claimedByUser: {
+          id: undefined,
+          name: undefined,
+          profileImage: undefined,
+        },
+      };
       mockIssueRepository.findById.mockResolvedValue(mockIssue as any);
 
       const result = await issueService.getIssueById('123');
@@ -215,8 +227,34 @@ describe('IssueService', () => {
   describe('getNearbyIssues', () => {
     it('should return issues from the repository without an N+1 upvote count loop', async () => {
       const mockIssues = [
-        { id: 'issue-1', upvoteCount: 3 },
-        { id: 'issue-2', upvoteCount: 0 },
+        {
+          id: 'issue-1',
+          upvoteCount: 3,
+          claimedByOrg: {
+            id: undefined,
+            name: undefined,
+            profileImage: undefined,
+          },
+          claimedByUser: {
+            id: undefined,
+            name: undefined,
+            profileImage: undefined,
+          },
+        },
+        {
+          id: 'issue-2',
+          upvoteCount: 0,
+          claimedByOrg: {
+            id: undefined,
+            name: undefined,
+            profileImage: undefined,
+          },
+          claimedByUser: {
+            id: undefined,
+            name: undefined,
+            profileImage: undefined,
+          },
+        },
       ];
       mockIssueRepository.findNearby.mockResolvedValue(mockIssues as any);
 

--- a/backend/src/services/__tests__/unit/login.service.test.ts
+++ b/backend/src/services/__tests__/unit/login.service.test.ts
@@ -6,6 +6,7 @@ import { describe, beforeEach, vi, it, expect, Mocked, Mock } from 'vitest';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { AppError } from '../../../utils/errors';
+import { UserRole } from '@civickit/shared/src/enums/user';
 
 // mock repository
 vi.mock('../../../src/repositories/login.repository');
@@ -38,6 +39,7 @@ describe('LoginService', () => {
     });
 
     const date = new Date();
+    const role: UserRole = "REPORTER"
     const mockUser = () => ({
         id: '1',
         email: 'test@example.com',
@@ -45,7 +47,8 @@ describe('LoginService', () => {
         passwordHash: 'hashedPassword',
         profileImage: '',
         createdAt: date,
-        updatedAt: date
+        updatedAt: date,
+        role: role
     });
 
     it('should login successfully and return token + user', async () => {
@@ -80,7 +83,8 @@ describe('LoginService', () => {
                 name: 'Test User',
                 email: 'test@example.com',
                 createdAt: date.toString(),
-                profileImage: ''
+                profileImage: '',
+                role: "REPORTER"
             },
         });
     });

--- a/backend/src/services/__tests__/unit/timeline.service.test.ts
+++ b/backend/src/services/__tests__/unit/timeline.service.test.ts
@@ -112,7 +112,7 @@ describe('TimelineService', () => {
 
         it('should return updates attached to user1', async () => {
             const mockUser = { id: 'user1' };
-            const mockUpdate = {
+            const mockUpdate = [{
                 issueId: 'issue1',
                 id: 'update1',
                 createdAt: new Date(),
@@ -120,10 +120,10 @@ describe('TimelineService', () => {
                 message: 'test message 1',
                 status: 'ACKNOWLEDGED',
                 images: []
-            };
+            }];
             mockTimelineRepository.findByUser.mockResolvedValue(mockUpdate as any);
             const result = await timelineService.getUserUpdates(mockUser.id)
-
+            console.log("!!!!!", result)
             expect(result.updates).toEqual(mockUpdate);
         });
 

--- a/backend/src/services/__tests__/unit/timeline.service.test.ts
+++ b/backend/src/services/__tests__/unit/timeline.service.test.ts
@@ -6,6 +6,7 @@ import { describe, beforeEach, vi, it, expect, Mocked, Mock } from 'vitest';
 import { CreateIssueDTO, PostUpdateDTO } from '@civickit/shared/src/types/api';
 import { IssueService } from '../../issue.service';
 import { IssueRepository } from '../../../repositories/issue.repository';
+import { AuthRepository } from '../../../repositories/auth.repository';
 
 // mock repository
 vi.mock('../../../src/repositories/timeline.repository');
@@ -16,6 +17,7 @@ describe('TimelineService', () => {
 
     let issueService: IssueService;
     let mockIssueRepository: Mocked<IssueRepository>;
+    let mockAuthRepository: Mocked<AuthRepository>;
 
 
     beforeEach(() => {
@@ -32,7 +34,13 @@ describe('TimelineService', () => {
             findNearby: vi.fn(),
         } as unknown as Mocked<IssueRepository>;
 
-        timelineService = new TimelineService(mockTimelineRepository);
+        mockAuthRepository = {
+            create: vi.fn(),
+            findById: vi.fn(),
+            findNearby: vi.fn(),
+        } as unknown as Mocked<AuthRepository>;
+
+        timelineService = new TimelineService(mockTimelineRepository, mockAuthRepository);
         issueService = new IssueService(mockIssueRepository);
         vi.clearAllMocks();
     });
@@ -95,7 +103,7 @@ describe('TimelineService', () => {
     describe('get', () => {
         it('should return updates attached to issue1', async () => {
             const mockIssue = { id: 'issue1' };
-            const mockUpdate = {
+            const mockUpdate = [{
                 issueId: 'issue1',
                 id: 'update1',
                 createdAt: new Date(),
@@ -103,7 +111,7 @@ describe('TimelineService', () => {
                 message: 'test message 1',
                 status: 'ACKNOWLEDGED',
                 images: []
-            };
+            }];
             mockTimelineRepository.findByIssue.mockResolvedValue(mockUpdate as any);
             const result = await timelineService.getIssueUpdates(mockIssue.id)
 
@@ -123,7 +131,6 @@ describe('TimelineService', () => {
             }];
             mockTimelineRepository.findByUser.mockResolvedValue(mockUpdate as any);
             const result = await timelineService.getUserUpdates(mockUser.id)
-            console.log("!!!!!", result)
             expect(result.updates).toEqual(mockUpdate);
         });
 

--- a/backend/src/services/issue.service.ts
+++ b/backend/src/services/issue.service.ts
@@ -68,4 +68,10 @@ export class IssueService {
 
     return this.issueRepository.updateStatus(id, { status });
   }
+
+  // claim an issue
+  // Callers must gate this behind requirePermission('update:claim_issue').
+  async claimIssue(issueId: string, claimedById: string) {
+    return this.issueRepository.claimIssue(issueId, { claimedById });
+  }
 }

--- a/backend/src/services/issue.service.ts
+++ b/backend/src/services/issue.service.ts
@@ -2,8 +2,11 @@
 
 import { IssueRepository } from '../repositories/issue.repository';
 import { CreateIssueDTO, IssueStatus } from '@civickit/shared';
-import { issueStatus } from '../db/schema';
+import { Issue, issueStatus } from '../db/schema';
 import { AppError } from '../utils/errors';
+import { OrgRepository } from '../repositories/org.repository';
+import { AuthRepository } from '../repositories/auth.repository';
+import { MembershipRepository } from '../repositories/membership.repository';
 
 /** Checked against the database enum, so the two cannot drift apart. */
 function isIssueStatus(value: unknown): value is IssueStatus {
@@ -12,6 +15,11 @@ function isIssueStatus(value: unknown): value is IssueStatus {
     (issueStatus.enumValues as readonly string[]).includes(value)
   );
 }
+
+
+const orgRepository = new OrgRepository()
+const authRepository = new AuthRepository()
+const membershipRepository = new MembershipRepository()
 
 export class IssueService {
   constructor(private issueRepository: IssueRepository) { }
@@ -32,8 +40,37 @@ export class IssueService {
     return this.issueRepository.create({ ...data, userId, status: 'REPORTED' });
   }
 
+  private async getClaimedByInfo(issues: Issue[]) {
+    let newIssues: any[] = []
+    for (let i = 0; i < issues.length; i++) {
+      let user = null
+      let org = null
+      if (issues[i].claimedById != null) {
+        user = await authRepository.findById(String(issues[i].claimedById))
+        const membershipOrgId = (await membershipRepository.findByUser(String(issues[i].claimedById)))?.organizationId
+        org = await orgRepository.findById(String(membershipOrgId))
+      }
+      newIssues[i] = {
+        ...issues[i],
+        claimedByUser: {
+          name: user?.name,
+          id: user?.id,
+          profileImage: user?.profileImage
+        },
+        claimedByOrg: {
+          name: org?.name,
+          id: org?.id,
+          profileImage: org?.profileImage
+        },
+      }
+    }
+    return newIssues
+  }
+
   async getNearbyIssues(lat: number, lng: number, radius?: number, limit?: number) {
-    return this.issueRepository.findNearby(lat, lng, radius, limit);
+    const issues = await this.issueRepository.findNearby(lat, lng, radius, limit);
+    const newIssues = this.getClaimedByInfo(issues)
+    return newIssues
   }
 
   async getIssueById(id: string) {
@@ -42,9 +79,11 @@ export class IssueService {
       throw new AppError('Issue not found', 404);
     }
 
+    const newIssue = (await this.getClaimedByInfo([issue]))[0]
+
     // findById already counts upvotes in the same statement that reads the row.
     // This used to issue a second countUpvotes query and return both values.
-    return issue;
+    return newIssue;
   }
 
   async getIssuesByUser(id: string, limit?: number) {
@@ -73,5 +112,11 @@ export class IssueService {
   // Callers must gate this behind requirePermission('update:claim_issue').
   async claimIssue(issueId: string, claimedById: string) {
     return this.issueRepository.claimIssue(issueId, { claimedById });
+  }
+
+  // release an issue
+  // Callers must gate this behind requirePermission('update:release_issue').
+  async releaseIssue(issueId: string) {
+    return this.issueRepository.releaseIssue(issueId);
   }
 }

--- a/backend/src/services/login.service.ts
+++ b/backend/src/services/login.service.ts
@@ -35,7 +35,8 @@ export class LoginService {
         name: String(user.name),
         email: String(user.email),
         createdAt: String(user.createdAt),
-        profileImage: String(user.profileImage)
+        profileImage: String(user.profileImage),
+        role: user.role
       }
     };
 

--- a/backend/src/services/membership.service.ts
+++ b/backend/src/services/membership.service.ts
@@ -1,0 +1,43 @@
+// backend/src/services/membership.service.ts
+
+import { OrgRepository } from '../repositories/org.repository';
+import { IssueCategory } from '@civickit/shared';
+import { AppError } from '../utils/errors';
+import { MembershipRepository } from '../repositories/membership.repository';
+import { OrgMembershipDTO } from '@civickit/shared/src/types/api';
+
+export class MembershipService {
+  constructor(private membershipRepository: MembershipRepository) { }
+
+  async createMembership(data: OrgMembershipDTO) {
+    return this.membershipRepository.create({ ...data });
+  }
+
+  async getOrgMemberships(orgId: string) {
+    const members = await this.membershipRepository.findByOrganization(orgId);
+    if (!members) {
+      throw new AppError('Organization not found', 404);
+    }
+
+    return members;
+  }
+
+  async getMembershipByUserId(userId: string) {
+    const member = await this.membershipRepository.findByUser(userId);
+    // if (!member) {
+    //   throw new AppError('Member not found', 404);
+    // }
+
+    return member;
+  }
+
+  async getMembershipById(id: string) {
+    const org = await this.membershipRepository.findById(id);
+    if (!org) {
+      throw new AppError('Organization not found', 404);
+    }
+
+    return org;
+  }
+
+}

--- a/backend/src/services/org.service.ts
+++ b/backend/src/services/org.service.ts
@@ -3,9 +3,41 @@
 import { OrgRepository } from '../repositories/org.repository';
 import { IssueCategory } from '@civickit/shared';
 import { AppError } from '../utils/errors';
+import { CreateOrgDTO } from '@civickit/shared/src/types/api';
+import { MembershipRepository } from '../repositories/membership.repository';
+
+const membershipRepository = new MembershipRepository()
 
 export class OrgService {
   constructor(private orgRepository: OrgRepository) { }
+
+  async createOrg(data: CreateOrgDTO, adminId: string) {
+    return this.orgRepository.create({ ...data, adminId: adminId });
+  }
+
+  async getOrgById(id: string) {
+    const org = await this.orgRepository.findById(id);
+    if (!org) {
+      throw new AppError('Organization not found', 404);
+    }
+
+    return org;
+  }
+
+  async getOrgByUserId(userId: string) {
+    const membership = await membershipRepository.findByUser(userId)
+    if (!membership) {
+      throw new AppError('Member not found', 404);
+    }
+
+    const org = await this.orgRepository.findById(membership.organizationId);
+    if (!org) {
+      throw new AppError('Organization not found', 404);
+    }
+
+    return org;
+  }
+
 
   async findOrgsForIssue(lat: number, lng: number, category: IssueCategory) {
     if (lat === undefined || lng === undefined) {

--- a/backend/src/services/timeline.service.ts
+++ b/backend/src/services/timeline.service.ts
@@ -1,7 +1,11 @@
 // backend/src/services/timeline.service.ts
 import { PostUpdateDTO } from '@civickit/shared/src/types/api';
 import { TimelineRepository } from '../repositories/timeline.repository';
+import { AuthRepository } from '../repositories/auth.repository';
+import { AuthService } from './auth.service';
 
+const authRepository = new AuthRepository()
+const authService = new AuthService(authRepository)
 export class TimelineService {
   constructor(private readonly timelineRepository: TimelineRepository) { }
 
@@ -13,18 +17,37 @@ export class TimelineService {
     }
   }
 
+
+
   async getIssueUpdates(issueId: string) {
     const updates = await this.timelineRepository.findByIssue(issueId)
 
+    let newUp: any[] = []
+    for (let i = 0; i < updates.length; i++) {
+      newUp[i] = {
+        ...updates[i],
+        userName: (await authRepository.findById(updates[i].userId))?.name
+      }
+    }
+
     return {
-      updates
+      updates: newUp
     };
   }
 
   async getUserUpdates(userId: string) {
     const updates = await this.timelineRepository.findByUser(userId)
+
+    let newUp: any[] = []
+    for (let i = 0; i < updates.length; i++) {
+      newUp[i] = {
+        ...updates[i],
+        username: (await authRepository.findById(updates[i].userId))?.name
+      }
+    }
+
     return {
-      updates
+      updates: newUp
     };
   }
 

--- a/backend/src/services/timeline.service.ts
+++ b/backend/src/services/timeline.service.ts
@@ -38,7 +38,8 @@ export class TimelineService {
   async getUserUpdates(userId: string) {
     const updates = await this.timelineRepository.findByUser(userId)
 
-    let newUp: any[] = []
+
+    let newUp: any[] | any = []
     for (let i = 0; i < updates.length; i++) {
       newUp[i] = {
         ...updates[i],

--- a/backend/src/services/timeline.service.ts
+++ b/backend/src/services/timeline.service.ts
@@ -4,10 +4,8 @@ import { TimelineRepository } from '../repositories/timeline.repository';
 import { AuthRepository } from '../repositories/auth.repository';
 import { AuthService } from './auth.service';
 
-const authRepository = new AuthRepository()
-const authService = new AuthService(authRepository)
 export class TimelineService {
-  constructor(private readonly timelineRepository: TimelineRepository) { }
+  constructor(private readonly timelineRepository: TimelineRepository, private readonly authRepository: AuthRepository) { }
 
   async postUpdate(data: PostUpdateDTO, issueId: string, userId: string) {
     try {
@@ -26,10 +24,9 @@ export class TimelineService {
     for (let i = 0; i < updates.length; i++) {
       newUp[i] = {
         ...updates[i],
-        userName: (await authRepository.findById(updates[i].userId))?.name
+        userName: (await this.authRepository.findById(updates[i].userId))?.name
       }
     }
-
     return {
       updates: newUp
     };
@@ -43,10 +40,9 @@ export class TimelineService {
     for (let i = 0; i < updates.length; i++) {
       newUp[i] = {
         ...updates[i],
-        username: (await authRepository.findById(updates[i].userId))?.name
+        username: (await this.authRepository.findById(updates[i].userId))?.name
       }
     }
-
     return {
       updates: newUp
     };

--- a/mobile/src/api/index.ts
+++ b/mobile/src/api/index.ts
@@ -7,3 +7,4 @@ export { queryKeys } from './queryKeys';
 export * as authApi from './auth';
 export * as issuesApi from './issues';
 export * as uploadApi from './upload';
+export * as orgsApi from './orgs'

--- a/mobile/src/api/issues.ts
+++ b/mobile/src/api/issues.ts
@@ -38,6 +38,7 @@ export interface TimelineEntry {
     message: string;
     status: string;
     images: string[];
+    userName: string;
 }
 
 export interface NearbyIssuesParams {
@@ -95,6 +96,10 @@ export function getUpvoteState(issueId: string, signal?: AbortSignal): Promise<U
     return apiFetch(`/issues/${encodeURIComponent(issueId)}/upvote`, { auth: true, signal });
 }
 
+export function getIssueById(issueId: string, signal?: AbortSignal): Promise<Issue> {
+    return apiFetch(`/issues/${encodeURIComponent(issueId)}/`, { auth: true, signal });
+}
+
 export function addUpvote(issueId: string): Promise<UpvoteState> {
     return apiFetch(`/issues/${encodeURIComponent(issueId)}/upvote`, {
         method: 'POST',
@@ -124,5 +129,17 @@ export function getTimelineEntries(
     return apiFetch(`/issues/${encodeURIComponent(issueId)}/updates`, {
         method: 'GET',
         auth: true
+    });
+}
+
+export function claimIssue(issueId: string): Promise<Issue> {
+    return apiFetch(`/issues/${encodeURIComponent(issueId)}/claim`, {
+        method: 'POST', auth: true
+    });
+}
+
+export function releaseIssue(issueId: string): Promise<Issue> {
+    return apiFetch(`/issues/${encodeURIComponent(issueId)}/release`, {
+        method: 'POST', auth: true
     });
 }

--- a/mobile/src/api/orgs.ts
+++ b/mobile/src/api/orgs.ts
@@ -1,0 +1,29 @@
+// mobile/src/api/orgs.ts
+import type { CreateIssueDTO, GetNearbyIssueResponse, Issue, OrgRole, PostUpdateDTO, User } from '@civickit/shared';
+import { apiFetch } from './client';
+
+export interface Membership {
+    userId: string;
+    organizationId: string;
+    role: OrgRole
+}
+
+export function getMembershipByUserId(
+    userId: string,
+    options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<Membership> {
+    return apiFetch(`/organizations/${encodeURIComponent(userId)}/getMembershipByUserId`, {
+        method: 'GET',
+        auth: true
+    });
+}
+
+export function getOrgByUserId(
+    userId: string,
+    options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<Membership> {
+    return apiFetch(`/organizations/${encodeURIComponent(userId)}/getOrgByUserId`, {
+        method: 'GET',
+        auth: true
+    });
+}

--- a/mobile/src/components/CalloutListPopup.tsx
+++ b/mobile/src/components/CalloutListPopup.tsx
@@ -32,7 +32,6 @@ export default function CalloutListPopup({ style, cluster, onClosePress }: any) 
                             key={issue.id}
                             issue={issue}
                             animated={true}
-                            onPress={() => { navigation.navigate("Issue Details", { issue: issue }) }}
                         />
                     )}
                 </ScrollView>

--- a/mobile/src/components/CalloutPopup.tsx
+++ b/mobile/src/components/CalloutPopup.tsx
@@ -6,16 +6,34 @@ import IssueCard from "./IssueCard";
 import WrapperButton from "./WrapperButton";
 import { CloseXIcon, RightArrowIcon } from "./Icons";
 import { GetNearbyIssueResponse, Issue } from "@civickit/shared";
+import { useCallback, useState } from "react";
+import { useFocusEffect, useNavigation } from "@react-navigation/native";
+import { issuesApi } from "../api";
+import { StackParams } from "../types/StackParams";
+import { StackNavigationProp } from "@react-navigation/stack";
 
 interface CalloutProps {
     style?: any,
     issue: GetNearbyIssueResponse | undefined,
     onClosePress: () => void,
-    onForwardPress: () => void
+    onForwardPress?: null | (() => void)
 }
-export default function CalloutPopup({ style, issue, onClosePress, onForwardPress }: CalloutProps) {
+export default function CalloutPopup({ style, issue, onClosePress, onForwardPress = null }: CalloutProps) {
+    const [localIssue, setLocalIssue] = useState(issue)
+    const navigation = useNavigation<StackNavigationProp<StackParams>>();
+    useFocusEffect(
+        useCallback(() => {
+            const getIssue = async () => {
+                //get updates to issue
+                if (issue) {
+                    setLocalIssue({ ...(await issuesApi.getIssueById(issue.id)), distance: issue?.distance })
+                }
+            }
+            getIssue()
+        }, [])
+    )
 
-    if (issue != undefined) {
+    if (localIssue != undefined) {
         return (
             <View style={{ ...styles.container, ...style, }}>
                 <WrapperButton style={styles.button}
@@ -23,18 +41,18 @@ export default function CalloutPopup({ style, issue, onClosePress, onForwardPres
                     <CloseXIcon size={typography.sizeXl + 4} color={colors.textPrimary} />
                 </WrapperButton>
                 <TouchableOpacity style={styles.touchable}
-                    onPress={onForwardPress}
+                    onPress={onForwardPress ? onForwardPress : () => { navigation.navigate("Issue Details", { issue: localIssue }) }}
                     activeOpacity={0.6}
                 >
                     <IssueCard
-                        issue={issue}
+                        issue={localIssue}
                         variant="expanded"
                         style={{
                             borderRadius: 0,
                             backgroundColor: colors.background,
 
                         }}
-                        onPress={onForwardPress}
+                        onPress={onForwardPress ? onForwardPress : () => { navigation.navigate("Issue Details", { issue: localIssue }) }}
                         animated={false}
                     />
                     <View style={styles.button}

--- a/mobile/src/components/CalloutPopup.tsx
+++ b/mobile/src/components/CalloutPopup.tsx
@@ -21,6 +21,7 @@ interface CalloutProps {
 export default function CalloutPopup({ style, issue, onClosePress, onForwardPress = null }: CalloutProps) {
     const [localIssue, setLocalIssue] = useState(issue)
     const navigation = useNavigation<StackNavigationProp<StackParams>>();
+
     useFocusEffect(
         useCallback(() => {
             const getIssue = async () => {
@@ -30,7 +31,7 @@ export default function CalloutPopup({ style, issue, onClosePress, onForwardPres
                 }
             }
             getIssue()
-        }, [])
+        }, [issue])
     )
 
     if (localIssue != undefined) {

--- a/mobile/src/components/Icons.tsx
+++ b/mobile/src/components/Icons.tsx
@@ -12,6 +12,7 @@ import FontAwesome5 from '@expo/vector-icons/FontAwesome5';
 import EvilIcons from '@expo/vector-icons/EvilIcons';
 import Octicons from '@expo/vector-icons/Octicons';
 import Ionicons from '@expo/vector-icons/Ionicons';
+import FontAwesome6 from '@expo/vector-icons/FontAwesome6';
 
 interface IconProps {
     color?: string,
@@ -394,7 +395,7 @@ export function EditIcon(props: IconProps) {
 
 export function CheckMarkCircleIcon(props: IconProps) {
     return (
-        <AntDesign name="check-circle"
+        <FontAwesome6 name="check-circle"
             color={props.color}
             size={props.size}
             style={props.style} />
@@ -422,6 +423,16 @@ export function LineGraphIcon(props: IconProps) {
 export function CheckMarkIcon(props: IconProps) {
     return (
         <Entypo name="check"
+            color={props.color}
+            size={props.size}
+            style={props.style} />
+    )
+}
+
+
+export function CheckMarkDoneIcon(props: IconProps) {
+    return (
+        <MaterialIcons name="done-all"
             color={props.color}
             size={props.size}
             style={props.style} />

--- a/mobile/src/components/IssueCard.tsx
+++ b/mobile/src/components/IssueCard.tsx
@@ -63,7 +63,7 @@ export default function IssueCard({ issue, variant = 'compact', onPress, style, 
     <Animated.View
       style={[
         globalStyles.card,
-        isExpanded ? { height: size.cardExpanded } : { height: size.cardCompact },
+        isExpanded && { height: size.cardExpanded },// : { height: size.cardCompact },
         { transform: [{ scale }] },
         style
       ]}
@@ -112,8 +112,16 @@ export default function IssueCard({ issue, variant = 'compact', onPress, style, 
           {/* Footer row */}
           <View style={styles.footer}>
 
-            {/* Status badge */}
-            <StatusBadge status={issue.status} />
+            <View style={{ flexDirection: "row", alignItems: "center", columnGap: spacing.xs }}>
+              {/* Status badge */}
+              <StatusBadge status={issue.status} />
+              {/* Org that claimed issue */}
+              {issue.claimedById &&
+                issue.claimedByOrg?.profileImage &&
+                <Image source={{ uri: issue.claimedByOrg.profileImage }} style={styles.orgProfilePic} />
+
+              }
+            </View>
 
             <View style={{ flexDirection: "row", columnGap: spacing.xs }}>
               {!isExpanded && (
@@ -156,6 +164,12 @@ const styles = StyleSheet.create({
   content: {
     flex: 1,
     justifyContent: 'space-between',
+  },
+
+  orgProfilePic: {
+    width: size.lg,
+    height: size.lg,
+    borderRadius: borderRadius.full
   },
   row: {
     flexDirection: 'row',

--- a/mobile/src/components/IssueSquare.tsx
+++ b/mobile/src/components/IssueSquare.tsx
@@ -1,6 +1,6 @@
 // mobile/src/components/IssueSquare.tsx
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { GetNearbyIssueResponse } from '@civickit/shared'
 import {
     View,
@@ -15,42 +15,62 @@ import { globalStyles } from '../styles';
 import { borderRadius, colors, size, spacing, typography } from '../styles';
 import { BrokenIcon, ExclamationPointIcon, LightBulbIcon, LocationPinIcon, RoadIcon, SprayPaintIcon, TrafficConeIcon, TrafficLightIcon, TrashIcon, UpvoteIcon } from './Icons';
 import { statusColors } from '../styles/theme';
+import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import { issuesApi } from '../api';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { StackParams } from '../types/StackParams';
 
 interface IssueCardProps {
     issue: GetNearbyIssueResponse;
     variant?: 'compact' | 'expanded';
-    onPress?: () => void;
+    onPress?: null | (() => void);
     style?: any;
     animated?: boolean
 }
 
-export default function IssueSquare({ issue, variant = 'compact', onPress, style, animated = true }: IssueCardProps) {
+export default function IssueSquare({ issue, variant = 'compact', onPress = null, style, animated = true }: IssueCardProps) {
     const scale = useRef(new Animated.Value(1)).current;
     const [icon, setIcon] = useState(<ExclamationPointIcon size={typography.sizeLg} color={colors.textPrimary} style={{ marginRight: spacing.xs }} />)
+    const navigation = useNavigation<StackNavigationProp<StackParams>>();
+
+    const [localIssue, setLocalIssue] = useState(issue)
+    useFocusEffect(
+        useCallback(() => {
+            const getIssue = async () => {
+                //get updates to issue
+                if (issue) {
+                    setLocalIssue({ ...(await issuesApi.getIssueById(issue.id)), distance: issue?.distance })
+                }
+
+            }
+            getIssue()
+        }, [])
+    )
 
     useEffect(() => {
-        if (issue.category == "POTHOLE") {
+        if (localIssue.category == "POTHOLE") {
             setIcon(<TrafficConeIcon size={typography.sizeXl} color={colors.textPrimary}
                 style={styles.icon} />)
-        } else if (issue.category == "STREETLIGHT") {
+        } else if (localIssue.category == "STREETLIGHT") {
             setIcon(<LightBulbIcon size={typography.sizeLg} color={colors.textPrimary}
                 style={styles.icon} />)
-        } else if (issue.category == "GRAFFITI") {
-            setIcon(<SprayPaintIcon size={typography.sizeLg} color={colors.textPrimary} />)
-        } else if (issue.category == "ILLEGAL_DUMPING") {
+        } else if (localIssue.category == "GRAFFITI") {
+            setIcon(<SprayPaintIcon size={typography.sizeLg} color={colors.textPrimary}
+                style={styles.icon} />)
+        } else if (localIssue.category == "ILLEGAL_DUMPING") {
             setIcon(<TrashIcon size={typography.sizeLg} color={colors.textPrimary}
                 style={styles.icon} />)
-        } else if (issue.category == "BROKEN_SIDEWALK") {
+        } else if (localIssue.category == "BROKEN_SIDEWALK") {
             setIcon(<BrokenIcon size={typography.sizeLg} color={colors.textPrimary}
                 style={styles.icon} />)
-        } else if (issue.category == "TRAFFIC_SIGNAL") {
+        } else if (localIssue.category == "TRAFFIC_SIGNAL") {
             setIcon(<TrafficLightIcon size={typography.sizeLg} color={colors.textPrimary}
                 style={styles.icon} />)
         } else {
             setIcon(<ExclamationPointIcon size={typography.sizeLg} color={colors.textPrimary}
                 style={styles.icon} />)
         }
-    }, [issue])
+    }, [localIssue])
 
     const handlePressIn = (event: GestureResponderEvent) => {
         if (animated) {
@@ -74,7 +94,7 @@ export default function IssueSquare({ issue, variant = 'compact', onPress, style
     };
 
     const statusColor =
-        statusColors[issue.status.toLowerCase()] || statusColors.default;
+        statusColors[localIssue.status.toLowerCase()] || statusColors.default;
 
     const styles = StyleSheet.create({
         pressable: {
@@ -134,6 +154,9 @@ export default function IssueSquare({ issue, variant = 'compact', onPress, style
         },
 
     });
+
+
+    // console.log(onPress)
     return (
         <Animated.View
             style={[
@@ -142,15 +165,17 @@ export default function IssueSquare({ issue, variant = 'compact', onPress, style
             ]}
         >
             <Pressable
-                onPress={onPress}
+                onPress={onPress ? onPress : () => {
+                    navigation.navigate("Issue Details", { issue: localIssue })
+                }}
                 onPressIn={handlePressIn}
                 onPressOut={handlePressOut}
                 style={styles.pressable}
             >
                 <View>
-                    {issue.images?.length > 0 && (
+                    {localIssue.images?.length > 0 && (
                         <Image
-                            source={{ uri: issue.images[0] }}
+                            source={{ uri: localIssue.images[0] }}
                             style={styles.thumbnail}
                             resizeMode="cover"
                         />
@@ -159,16 +184,16 @@ export default function IssueSquare({ issue, variant = 'compact', onPress, style
                     <View style={styles.upvotes}>
                         <UpvoteIcon color={colors.textPrimary} size={typography.sizeLg} />
                         <Text style={styles.upvoteText}>
-                            {issue.upvoteCount}
+                            {localIssue.upvoteCount}
                         </Text>
                     </View>
                 </View>
 
-                {issue.distance !== undefined && (
+                {localIssue.distance !== undefined && (
                     <Text style={styles.distance}
                         numberOfLines={1}
                         ellipsizeMode="tail">
-                        {issue.title}
+                        {localIssue.title}
                     </Text>
                 )}
 

--- a/mobile/src/components/ModalPopup.tsx
+++ b/mobile/src/components/ModalPopup.tsx
@@ -4,10 +4,10 @@ import { FlatList, Modal, TouchableOpacity, View, StyleSheet } from "react-nativ
 import WrapperButton from "./WrapperButton";
 import { useState } from "react";
 import Checkbox from "expo-checkbox";
-import { palette, typography, colors, borderRadius, spacing } from "../styles";
+import { palette, typography, colors, borderRadius, spacing, globalStyles } from "../styles";
 import Button from "./Button";
 
-export default function ModalPopUp({ buttonStyle, buttonBody, style, children }: any) {
+export default function ModalPopUp({ buttonStyle, buttonBody, closeButtonBody, closeButtonStyle, style, children }: any) {
     const [isVisible, setIsVisible] = useState(false)
     const toggleModal = () => setIsVisible(!isVisible)
 
@@ -21,9 +21,18 @@ export default function ModalPopUp({ buttonStyle, buttonBody, style, children }:
                 <View style={{ ...styles.modalBackground, }}>
                     <View style={{ ...styles.modalContent, ...style }}>
                         {children}
-                        <Button style={styles.closeButton} onPress={toggleModal}
-                            text="Close">
-                        </Button>
+
+                        {closeButtonBody ?
+                            <TouchableOpacity style={{ ...styles.closeButton, ...closeButtonStyle }} onPress={toggleModal}>
+                                {closeButtonBody}
+                            </TouchableOpacity>
+                            :
+                            <Button style={styles.closeButton} onPress={toggleModal}
+                                text="Close">
+                            </Button>
+                        }
+
+
                     </View>
                 </View>
             </Modal>
@@ -62,7 +71,8 @@ const styles = StyleSheet.create({
         fontSize: typography.sizeLg
     },
     closeButton: {
+        ...globalStyles.button,
         backgroundColor: palette.ckRed,
-        fontSize: typography.sizeLg
+        fontSize: typography.sizeLg,
     }
 })

--- a/mobile/src/components/TimelineEntry.tsx
+++ b/mobile/src/components/TimelineEntry.tsx
@@ -7,14 +7,12 @@ import CategoryIcon from "./CategoryIcon";
 import ModalPopUp from "./ModalPopup";
 import ImageGallery from "./ImageGallery";
 import { statusColors } from "../styles/theme";
-import { getUserById } from "../api/auth";
 import { authApi } from "../api";
 
 export default function TimelineEntry({ timelineEntry, issueCategory = "OTHER", first = false, last = false, anonymous = false }: any) {
 
     const [date, setDate] = useState(new Date(timelineEntry.createdAt))
     const [height, setHeight] = useState(0)
-    const [author, setAuthor] = useState<any>()
     const HOURS24 = 86400000
     const isNew = new Date().valueOf() - new Date(timelineEntry.createdAt).valueOf() < HOURS24
 
@@ -23,16 +21,6 @@ export default function TimelineEntry({ timelineEntry, issueCategory = "OTHER", 
         pictures = timelineEntry.images.map((image: any, index: number) =>
             <Image source={{ uri: image }} key={index} style={styles.picture} />)
     }
-
-    useEffect(() => {
-        const getEntries = async () => {
-            const user = await authApi.getUserById(timelineEntry.userId)
-            setAuthor(user)
-        }
-
-        getEntries()
-
-    }, [timelineEntry]);
 
     return (
         <View style={styles.container}>
@@ -65,11 +53,11 @@ export default function TimelineEntry({ timelineEntry, issueCategory = "OTHER", 
             <View style={styles.rightContainer} onLayout={(e) => setHeight(e.nativeEvent.layout.height)}>
                 <View style={{
                     flexDirection: "row", columnGap: spacing.sm, flexWrap: "wrap",
-                    marginHorizontal: spacing.sm
+                    marginHorizontal: spacing.xs,
                 }}>
                     {/* eventually check if user is reporter or responder and hide based on that */}
-                    {(!anonymous && author != undefined) &&
-                        <Text style={styles.author}>{author.name}</Text>}
+                    {(!anonymous && timelineEntry.userName != undefined) &&
+                        <Text style={styles.author}>{timelineEntry.userName}</Text>}
                     {(anonymous) &&
                         <Text style={styles.author}>User</Text>}
                     <Text style={styles.timestamp}>{
@@ -170,11 +158,13 @@ const styles = StyleSheet.create({
     timestamp: {
         fontSize: typography.sizeMd,
         color: colors.textSecondary,
+        alignSelf: "center"
     },
     author: {
         fontSize: typography.sizeMd,
         color: colors.textSecondary,
-        fontWeight: typography.weightMedium
+        fontWeight: typography.weightMedium,
+        alignSelf: "center"
     },
     statusText: {
         fontSize: typography.sizeLg,

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -3,8 +3,9 @@ import React, { createContext, useContext, useEffect, useState } from 'react';
 import { getToken, saveToken, deleteToken } from '../services/tokenStorage';
 import { User } from '@civickit/shared';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { authApi, queryKeys, setUnauthorizedHandler } from '../api';
+import { authApi, queryKeys, setUnauthorizedHandler, orgsApi } from '../api';
 
+type Role = "REPORTER" | "ORG_MEMBER" | "ORG_ADMIN" | "ADMIN"
 interface AuthContextType {
     isLoggedIn: boolean;
     isLoading: boolean;
@@ -13,6 +14,8 @@ interface AuthContextType {
     setUser: (user: User) => void;
     authToken: string | null;
     user: User | null;
+    role: Role | null
+    organization: any
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -22,6 +25,8 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const [isLoading, setIsLoading] = useState(true);
     const [authToken, setAuthToken] = useState<string | null>(null);
     const [user, setUser] = useState<User | null>(null);
+    const [role, setRole] = useState<Role | null>(null)
+    const [organization, setOrganization] = useState<any>(null)
     const queryClient = useQueryClient()
 
     // On mount, check for token to determine if user is logged in
@@ -35,11 +40,41 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         })();
     }, []); //no dependencies bc it runs once on mount to check for token
 
+    //get user role
+    useEffect(() => {
+        const getOrgRole = async (userId: string) => {
+            const membership = await orgsApi.getMembershipByUserId(userId)
+            if (!membership) {
+                setRole("REPORTER")
+            } else {
+                setRole(membership.role)
+            }
+        }
+
+        const getOrgByUserId = async (userId: any) => {
+            setOrganization(await orgsApi.getOrgByUserId(userId))
+        }
+
+        if (user != null) {
+            if (user.role == "REPORTER") {
+                getOrgRole(user.id)
+                getOrgByUserId(user.id)
+            } else if (user.role == "ADMIN") {
+                setRole("ADMIN")
+            }
+
+
+        }
+
+
+    }, [user])
+
     //logout deletes token + updates state
     const logout = async () => {
         await deleteToken();
         setAuthToken(null);
         setUser(null)
+        setRole(null)
         setIsLoggedIn(false);
         queryClient.clear();
     };
@@ -81,7 +116,7 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 
 
     return (
-        <AuthContext.Provider value={{ isLoggedIn, isLoading, authToken, login, logout, setUser, user }}>
+        <AuthContext.Provider value={{ isLoggedIn, isLoading, authToken, login, logout, setUser, user, role, organization }}>
             {children}
         </AuthContext.Provider>
     );

--- a/mobile/src/screens/IssueCreation/IssueCreationNav.tsx
+++ b/mobile/src/screens/IssueCreation/IssueCreationNav.tsx
@@ -80,7 +80,8 @@ export default function IssueCreationNav() {
                 <Stack.Screen name="Error" component={ErrorScreen}
                     options={{
                         headerTitle: "",
-                        headerShadowVisible: false
+                        headerShadowVisible: false,
+                        headerBackVisible: false,
                     }} />
             </Stack.Navigator>
         </ContextWrapper>

--- a/mobile/src/screens/IssueCreation/IssueCreationScreen.tsx
+++ b/mobile/src/screens/IssueCreation/IssueCreationScreen.tsx
@@ -142,8 +142,6 @@ export default function IssueCreationScreen() {
         )
     }
 
-    console.log(photoMetadata)
-
     const handleCancel = () => {
         setImages([])
         setPhotoMetadata([])

--- a/mobile/src/screens/Landing/MapViewScreen.tsx
+++ b/mobile/src/screens/Landing/MapViewScreen.tsx
@@ -50,6 +50,7 @@ export default function MapViewScreen({ ref, issues, refetch }: any) {
     const location = useLocation().location
 
     const onMarkerPress = (element: MapElement) => {
+
         //large clusters zoom the map in instead of rendering a huge callout (#174)
         if (isCluster(element) && element.issues.length > 10) {
             ref?.current?.animateToRegion({

--- a/mobile/src/screens/Landing/MapViewScreen.tsx
+++ b/mobile/src/screens/Landing/MapViewScreen.tsx
@@ -30,7 +30,6 @@ type MapElement = GetNearbyIssueResponse | IssueCluster
 function isCluster(element: MapElement): element is IssueCluster {
     return (element as IssueCluster).issues != undefined
 }
-import { showLocation } from 'react-native-map-link';
 
 export default function MapViewScreen({ ref, issues, refetch }: any) {
     const navigation = useNavigation<StackNavigationProp<StackParams>>();
@@ -231,9 +230,6 @@ export default function MapViewScreen({ ref, issues, refetch }: any) {
                             closeCallout(() => {
                                 setCurrentElement(undefined)
                             })
-                        }}
-                        onForwardPress={() => {
-                            navigation.navigate("Issue Details", { issue: currentElement! })
                         }}
                     />
                 }

--- a/mobile/src/screens/Login/LoginScreen.tsx
+++ b/mobile/src/screens/Login/LoginScreen.tsx
@@ -165,6 +165,7 @@ const styles = StyleSheet.create({
     flex: {
         flex: 1,
         backgroundColor: colors.surface,
+        paddingVertical: spacing.md
     },
     container: {
         //paddingTop is supplied inline from the safe-area inset

--- a/mobile/src/screens/Login/RegisterScreen.tsx
+++ b/mobile/src/screens/Login/RegisterScreen.tsx
@@ -215,6 +215,7 @@ const styles = StyleSheet.create({
     flex: {
         flex: 1,
         backgroundColor: colors.surface,
+        paddingVertical: spacing.md
     },
     container: {
         //paddingTop is supplied inline from the safe-area inset

--- a/mobile/src/screens/Misc/IssueDetailScreen.tsx
+++ b/mobile/src/screens/Misc/IssueDetailScreen.tsx
@@ -20,6 +20,8 @@ import Timeline from '../../components/Timeline';
 import { useAuth } from '../../contexts/AuthContext';
 import ModalPopUp from '../../components/ModalPopup';
 import { popup } from 'leaflet';
+import { StackParams } from '../../types/StackParams';
+import { StackNavigationProp } from '@react-navigation/stack';
 
 let MapView: any = null;
 let Marker: any = null;
@@ -55,7 +57,7 @@ const IssueDetailScreen = () => {
   const [timelineEntries, setTimelineEntries] = useState<any[]>()
   const [loading, setLoading] = useState(false);
 
-  const navigation = useNavigation();
+  const navigation = useNavigation<StackNavigationProp<StackParams>>()
 
   const resolvedAddress = issue.address || 'No address available';
   const formatSource = (source?: string) => source === 'exif' ? 'Photo metadata' : 'Device GPS';
@@ -121,20 +123,31 @@ const IssueDetailScreen = () => {
   };
 
   const handleClaim = async () => {
-    await issuesApi.claimIssue(issue.id)
-    await issuesApi.addTimelineEntry(issue.id, {
-      message: organization.name + " claimed this issue",
-      status: "ACKNOWLEDGED"
-    })
-    setIssue(await issuesApi.getIssueById(issue.id))
+    try {
+      await issuesApi.claimIssue(issue.id)
+      await issuesApi.addTimelineEntry(issue.id, {
+        message: organization.name + " claimed this issue",
+        status: "ACKNOWLEDGED"
+      })
+      setIssue(await issuesApi.getIssueById(issue.id))
+    } catch (error) {
+      console.log(error)
+      navigation.push('Error', { errorMessage: 'Issue Claim Failed' });
+      throw error;
+    }
   }
 
   const handleRelease = async () => {
-    await issuesApi.addTimelineEntry(issue.id, {
-      message: releaseMessage.length > 0 ? organization.name + " unclaimed this issue: " + releaseMessage : organization.name + " unclaimed this issue",
-      status: "REPORTED"
-    })
-    setIssue(await issuesApi.releaseIssue(issue.id))
+    try {
+      await issuesApi.addTimelineEntry(issue.id, {
+        message: releaseMessage.length > 0 ? organization.name + " unclaimed this issue: " + releaseMessage : organization.name + " unclaimed this issue",
+        status: "REPORTED"
+      })
+      setIssue(await issuesApi.releaseIssue(issue.id))
+    } catch (error) {
+      navigation.push('Error', { errorMessage: 'Issue Release Failed' });
+      throw error;
+    }
 
   }
 

--- a/mobile/src/screens/Misc/IssueDetailScreen.tsx
+++ b/mobile/src/screens/Misc/IssueDetailScreen.tsx
@@ -47,7 +47,6 @@ const IssueDetailScreen = () => {
   const [upvoteCount, setUpvoteCount] = useState(issue.upvoteCount ?? 0);
   const [timelineEntries, setTimelineEntries] = useState<any[]>()
   const [loading, setLoading] = useState(false);
-  const [activeImageIndex, setActiveImageIndex] = useState(0);
 
   const navigation = useNavigation();
 
@@ -92,6 +91,8 @@ const IssueDetailScreen = () => {
     getEntries()
 
   }, [issue.id]);
+
+  //claimById -> orgMembership -> orgId -> org
 
 
   const handleEndorse = async () => {

--- a/mobile/src/screens/Misc/IssueDetailScreen.tsx
+++ b/mobile/src/screens/Misc/IssueDetailScreen.tsx
@@ -1,13 +1,13 @@
 // mobile/src/screens/Misc/IssueDetailScreen.tsx
-import React, { useState, useEffect } from 'react';
-import { Platform, Text, ScrollView, FlatList, Image, StyleSheet, View, TouchableOpacity, useWindowDimensions, useAnimatedValue } from 'react-native';
-import { useRoute, RouteProp, useNavigation } from '@react-navigation/native';
+import React, { useState, useEffect, useCallback } from 'react';
+import { Platform, Text, ScrollView, FlatList, Image, StyleSheet, View, TouchableOpacity, useWindowDimensions, useAnimatedValue, TextInput } from 'react-native';
+import { useRoute, RouteProp, useNavigation, useFocusEffect } from '@react-navigation/native';
 import { GetNearbyIssueResponse, Issue } from '@civickit/shared';
 import { format, formatDistanceToNow } from 'date-fns';
-import { DefaultCategoryIcon, CheckMarkCircleIcon, CheckMarkIcon, ClockIcon, LocationPinIcon, TagIcon, UpvoteIcon, WrenchIcon, TextIcon } from '../../components/Icons';
+import { DefaultCategoryIcon, CheckMarkCircleIcon, CheckMarkIcon, ClockIcon, LocationPinIcon, TagIcon, UpvoteIcon, WrenchIcon, TextIcon, CheckMarkDoneIcon } from '../../components/Icons';
 import { borderRadius, colors, globalStyles, palette, size, spacing, typography } from '../../styles';
 import { PROVIDER_GOOGLE } from 'react-native-maps/lib/ProviderConstants';
-import { issuesApi } from '../../api';
+import { authApi, issuesApi, orgsApi } from '../../api';
 import Pin from '../../components/Pin';
 import { showLocation } from 'react-native-map-link';
 import Header from '../../components/Header';
@@ -17,6 +17,9 @@ import CategoryIcon from '../../components/CategoryIcon';
 import TimelineEntry from '../../components/TimelineEntry';
 import ImageGallery from '../../components/ImageGallery';
 import Timeline from '../../components/Timeline';
+import { useAuth } from '../../contexts/AuthContext';
+import ModalPopUp from '../../components/ModalPopup';
+import { popup } from 'leaflet';
 
 let MapView: any = null;
 let Marker: any = null;
@@ -38,12 +41,16 @@ const IssueDetailScreen = () => {
   //seeded with a sensible default so the first frame is reasonable; Header
   //reports its real height on layout and corrects this
   const [headerOffset, setHeaderOffset] = useState(spacing.xxxl)
-  const { issue } = route.params;
+  const [issue, setIssue] = useState<Issue | GetNearbyIssueResponse>(route.params.issue);
+
   const { width } = useWindowDimensions();
   const imageWidth = width - spacing.md * 2;
   const imageHeight = imageWidth * 1.25;
+  const { role, organization, user } = useAuth()
+  const [releaseMessage, setReleaseMessage] = useState("")
 
   const [hasEndorsed, setHasEndorsed] = useState(false);
+
   const [upvoteCount, setUpvoteCount] = useState(issue.upvoteCount ?? 0);
   const [timelineEntries, setTimelineEntries] = useState<any[]>()
   const [loading, setLoading] = useState(false);
@@ -64,7 +71,7 @@ const IssueDetailScreen = () => {
     }
   }
 
-
+  //get upvotes
   useEffect(() => {
     const controller = new AbortController();
 
@@ -82,17 +89,15 @@ const IssueDetailScreen = () => {
     return () => controller.abort();
   }, [issue.id]);
 
+  //get timeline entries when issue changes
   useEffect(() => {
     const getEntries = async () => {
       const timeline = await issuesApi.getTimelineEntries(issue.id)
       setTimelineEntries(timeline.updates)
     }
-
     getEntries()
 
-  }, [issue.id]);
-
-  //claimById -> orgMembership -> orgId -> org
+  }, [issue]);
 
 
   const handleEndorse = async () => {
@@ -114,6 +119,28 @@ const IssueDetailScreen = () => {
       setLoading(false);
     }
   };
+
+  const handleClaim = async () => {
+    await issuesApi.claimIssue(issue.id)
+    await issuesApi.addTimelineEntry(issue.id, {
+      message: organization.name + " claimed this issue",
+      status: "ACKNOWLEDGED"
+    })
+    setIssue(await issuesApi.getIssueById(issue.id))
+  }
+
+  const handleRelease = async () => {
+    await issuesApi.addTimelineEntry(issue.id, {
+      message: releaseMessage.length > 0 ? organization.name + " unclaimed this issue: " + releaseMessage : organization.name + " unclaimed this issue",
+      status: "REPORTED"
+    })
+    setIssue(await issuesApi.releaseIssue(issue.id))
+
+  }
+
+  const handleUpdate = async () => {
+    console.log("Update Pressed")
+  }
 
   const [category, setCategory] = useState<String>(issue.category.replace(/_/g, " ").toLowerCase())
 
@@ -154,11 +181,29 @@ const IssueDetailScreen = () => {
           height={imageHeight}
           width={imageWidth} />
 
+        {/* Claimed By */}
+        {issue.claimedById &&
+          <View style={{ ...styles.claimedByContainter }}>
+            {issue.claimedByOrg?.profileImage &&
+              <Image source={{ uri: issue.claimedByOrg.profileImage }} style={styles.orgProfilePic} />
+            }
+
+            <View>
+              <Text style={styles.claimedByLabel}>Issue Claimed By</Text>
+              <View style={{ flexDirection: "row", columnGap: spacing.xs }}>
+                <Text style={{ ...styles.claimedByText, fontWeight: typography.weightBold }}>{issue.claimedByUser?.name}</Text>
+                <Text style={styles.claimedByText}>with</Text>
+                <Text style={{ ...styles.claimedByText, fontWeight: typography.weightBold }}>{issue.claimedByOrg?.name}</Text>
+              </View>
+            </View>
+          </View>
+        }
+
         {/* Description */}
         <View style={{ ...styles.infoBlock, flexDirection: "row", columnGap: spacing.sm }}>
           <TextIcon color={colors.textPrimary}
             size={typography.sizeLg}
-            style={{ ...styles.icon, marginTop: spacing.xs }} />
+            style={{ marginTop: spacing.xs }} />
           {/* <Text style={styles.infoRowLabel}>Description</Text> */}
           <Text style={styles.infoRowText}>{issue.description}</Text>
         </View>
@@ -175,7 +220,7 @@ const IssueDetailScreen = () => {
             <View style={{ flexDirection: "row", columnGap: spacing.xs }}>
               <LocationPinIcon color={colors.textPrimary}
                 size={typography.sizeLg}
-                style={{ ...styles.icon, marginTop: spacing.xs }} />
+                style={{ marginTop: spacing.xs }} />
               <Text style={{ ...styles.infoRowText, textDecorationLine: 'underline' }}>
                 {resolvedAddress}
               </Text>
@@ -217,6 +262,35 @@ const IssueDetailScreen = () => {
         <Text style={styles.time}>
           Reported {formatDistanceToNow(new Date(issue.createdAt))} ago
         </Text>
+
+        {((role == "ORG_ADMIN" || role == "ORG_MEMBER") &&
+          (issue.claimedById != null && issue.claimedByOrg?.id == organization.id)) &&
+
+          <ModalPopUp
+            buttonBody={
+              <Text style={styles.releaseText}>Unclaim Issue</Text>}
+            closeButtonBody={<Text style={styles.cancelText}>Cancel</Text>}
+            closeButtonStyle={{ position: "relative" }}
+            buttonStyle={styles.releaseButton}
+          >
+            <View style={styles.popup}>
+              <Text style={styles.warningText}>Are you sure?</Text>
+              <TextInput onChangeText={setReleaseMessage}
+                value={releaseMessage}
+                placeholder='Add a note...'
+                style={styles.releaseMessage}
+                multiline
+                numberOfLines={5}
+                maxLength={500}
+                focusable
+              />
+              <TouchableOpacity style={styles.releaseButtonTwo} onPress={handleRelease}>
+                <Text style={styles.longButtonText}>Yes, unclaim this issue</Text>
+              </TouchableOpacity>
+            </View>
+          </ModalPopUp>
+
+        }
       </ScrollView>
 
       <Header title={issue.title}
@@ -224,17 +298,56 @@ const IssueDetailScreen = () => {
         lineNum={lineNum}
         setOffset={(i: any) => setHeaderOffset(i)} />
 
-      {/* Upvote / Endorse Button */}
-      <TouchableOpacity style={{ ...styles.endorseButton, backgroundColor: hasEndorsed ? palette.ckGreen : palette.ckRed }} onPress={handleEndorse}>
-        {hasEndorsed ?
-          <View style={{ flexDirection: "row", justifyContent: "center", alignItems: "center" }}>
-            <Text style={styles.endorseText}>Endorsed</Text>
-            <CheckMarkIcon color={colors.textContrast} size={typography.sizeXl} />
-          </View> :
-          <Text style={styles.endorseText}>Endorse</Text>
-        }
+      {/*TODO: add check for service area/*}
+      {/* Endorse / Claim / Update Button */}
+      {((role != "ORG_ADMIN" && role != "ORG_MEMBER") || //user is a reporter
+        (issue.claimedById != null && issue.claimedByOrg?.id != organization.id)) ? //issue claimed by a different org
 
-      </TouchableOpacity>
+        <TouchableOpacity style={{ ...styles.longButton, backgroundColor: hasEndorsed ? palette.ckGreen : palette.ckRed, bottom: spacing.ml, marginHorizontal: spacing.ml }} onPress={handleEndorse}>
+          {hasEndorsed ?
+            <View style={{ flexDirection: "row", justifyContent: "center", alignItems: "center" }}>
+              <Text style={styles.longButtonText}>Endorsed</Text>
+              <CheckMarkIcon color={colors.textContrast} size={typography.sizeXl} />
+            </View> :
+            <Text style={styles.longButtonText}>Endorse</Text>
+          }
+        </TouchableOpacity>
+        :
+        //responder
+        ((issue.claimedById != null && issue.claimedByUser?.id == user!.id || //user claimed this issue
+          (issue.claimedById != null && organization.id == issue.claimedByOrg?.id))) ?  //user's org claimed this issue
+
+          <View style={styles.buttonBar}>
+            <TouchableOpacity style={{ ...styles.littleEndorseButton, backgroundColor: hasEndorsed ? palette.ckGreen : palette.ckRed }} onPress={handleEndorse}>
+              {hasEndorsed ?
+                <View style={{ flexDirection: "row", justifyContent: "center", alignItems: "center" }}>
+                  <CheckMarkIcon color={colors.textContrast} size={typography.sizeXl} />
+                </View> :
+                <CheckMarkIcon color={colors.textContrast} size={typography.sizeXl} />
+              }
+            </TouchableOpacity>
+
+
+            <TouchableOpacity style={{ ...styles.longButton, backgroundColor: palette.ckGreen }} onPress={handleUpdate}>
+              <Text style={styles.longButtonText}>Update</Text>
+            </TouchableOpacity>
+          </View> :
+
+          <View style={styles.buttonBar}>
+            <TouchableOpacity style={{ ...styles.littleEndorseButton, backgroundColor: hasEndorsed ? palette.ckGreen : palette.ckRed }} onPress={handleEndorse}>
+              {hasEndorsed ?
+                <View style={{ flexDirection: "row", justifyContent: "center", alignItems: "center" }}>
+                  <CheckMarkIcon color={colors.textContrast} size={typography.sizeXl} />
+                </View> :
+                <CheckMarkIcon color={colors.textContrast} size={typography.sizeXl} />
+              }
+            </TouchableOpacity>
+            <TouchableOpacity style={{ ...styles.longButton, backgroundColor: palette.ckRed }} onPress={handleClaim}>
+              <Text style={styles.longButtonText}>Claim</Text>
+            </TouchableOpacity>
+          </View>
+
+      }
     </View>
   );
 }
@@ -268,17 +381,23 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
   },
 
+  releaseMessage: {
+    ...globalStyles.textBox,
+    ...globalStyles.bodyText,
+    minHeight: size.x4l,
+    justifyContent: "flex-start",
+    height: "auto",
+    width: "100%",
+    color: colors.textPrimary,
+
+  },
+
   catValue: {
     fontSize: typography.sizeLg,
     color: colors.textPrimary,
     fontWeight: typography.weightMedium
   },
 
-  infoCard: {
-    backgroundColor: palette.ckLightGray,
-    borderRadius: borderRadius.ml,
-    padding: spacing.sd,
-  },
 
   infoRowText: {
     fontSize: typography.sizeLg,
@@ -286,28 +405,36 @@ const styles = StyleSheet.create({
     //textTransform: 'capitalize' causes region to lowercase, and Pm to act weird, need to fix categories without doing this line because now tags is all lowercase
   },
 
-  infoRowLabel: {
-    fontSize: typography.sizeSm,
-    fontWeight: typography.weightBold,
+  claimedByText: {
+    fontSize: typography.sizeLg,
     color: colors.textPrimary,
+    //textTransform: 'capitalize' causes region to lowercase, and Pm to act weird, need to fix categories without doing this line because now tags is all lowercase
+  },
+
+  claimedByContainter: {
+    backgroundColor: colors.backgroundSecondary,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    paddingRight: spacing.md,
+    // alignSelf: "flex-start",
+    borderRadius: borderRadius.lg,
+    flexDirection: "row",
+    columnGap: spacing.xs,
+    alignItems: "center"
+
+  },
+
+  claimedByLabel: {
+    fontSize: typography.sizeSm,
+    fontWeight: typography.weightMedium,
+    color: colors.textPrimary,
+    marginLeft: spacing.xs
   },
 
   infoRowMeta: {
     fontSize: typography.sizeSm,
     color: colors.textMuted,
     marginTop: spacing.xs,
-  },
-
-  infoTextColumn: {
-    flex: 1,
-    gap: spacing.xs,
-  },
-
-  infoRow: {
-    flex: 1,
-    flexDirection: "row",
-    columnGap: spacing.sm,
-    paddingVertical: spacing.sm,
   },
 
   imageCaption: {
@@ -317,20 +444,6 @@ const styles = StyleSheet.create({
     justifyContent: "space-between"
   },
 
-  icon: {
-  },
-
-  divider: {
-    height: 1,
-    backgroundColor: palette.ckDarkGray,
-    marginVertical: spacing.xs,
-  },
-
-  image: {
-    borderRadius: borderRadius.md,
-    backgroundColor: palette.ckLightGray,
-    resizeMode: 'cover',
-  },
 
   infoBlock: {
     backgroundColor: colors.backgroundSecondary,
@@ -354,21 +467,76 @@ const styles = StyleSheet.create({
     color: palette.ckDarkGray,
   },
 
-  endorseButton: {
+  buttonBar: {
     position: 'absolute',
     bottom: spacing.ml,
-    left: spacing.ml,
-    right: spacing.ml,
+    paddingHorizontal: spacing.ml,
+    flexDirection: "row",
+    columnGap: spacing.sm,
+    width: "100%",
+  },
+
+  longButton: {
     backgroundColor: palette.ckRed,
     padding: spacing.md,
-    borderRadius: 40,
+    borderRadius: borderRadius.full,
     alignItems: 'center',
+    flexGrow: 1,
+    flexShrink: 0,
     ...globalStyles.shadow
   },
 
-  endorseText: {
+  littleEndorseButton: {
+    padding: spacing.md + 3,
+    borderRadius: borderRadius.full,
+    flexGrow: 0,
+    flexShrink: 0,
+    ...globalStyles.shadow
+  },
+
+  longButtonText: {
     fontSize: typography.sizeXl,
     fontWeight: 'bold',
     color: colors.textContrast
+  },
+
+  releaseButton: {
+    backgroundColor: palette.ckLightGray,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md,
+    borderRadius: borderRadius.full,
+    alignSelf: 'center',
+    marginTop: spacing.md
+  },
+  releaseText: {
+    color: colors.textSecondary,
+    fontSize: typography.sizeLg
+  },
+  cancelText: {
+    fontSize: typography.sizeXl,
+    fontWeight: 'bold',
+    color: colors.textContrast,
+  },
+  releaseButtonTwo: {
+    backgroundColor: palette.ckGreen,
+    paddingVertical: spacing.sm,
+    alignItems: "center",
+    borderRadius: borderRadius.full,
+    width: "100%"
+  },
+  warningText: {
+    color: colors.textPrimary,
+    fontSize: typography.sizeXl,
+    fontWeight: typography.weightMedium
+  },
+  popup: {
+    alignItems: "center",
+    rowGap: spacing.sm,
+    marginBottom: spacing.sm
+  },
+  orgProfilePic: {
+    width: size.xl,
+    height: size.xl,
+    borderRadius: borderRadius.full
   }
 },);

--- a/mobile/src/screens/Misc/IssueDetailScreen.tsx
+++ b/mobile/src/screens/Misc/IssueDetailScreen.tsx
@@ -188,12 +188,12 @@ const IssueDetailScreen = () => {
               <Image source={{ uri: issue.claimedByOrg.profileImage }} style={styles.orgProfilePic} />
             }
 
-            <View>
+            <View style={{ paddingLeft: !issue.claimedByOrg?.profileImage ? spacing.sm : 0 }}>
               <Text style={styles.claimedByLabel}>Issue Claimed By</Text>
-              <View style={{ flexDirection: "row", columnGap: spacing.xs }}>
+              <View style={{ flexDirection: "row", columnGap: spacing.xs, paddingLeft: !issue.claimedByOrg?.profileImage ? spacing.xs : 0 }}>
                 <Text style={{ ...styles.claimedByText, fontWeight: typography.weightBold }}>{issue.claimedByUser?.name}</Text>
                 <Text style={styles.claimedByText}>with</Text>
-                <Text style={{ ...styles.claimedByText, fontWeight: typography.weightBold }}>{issue.claimedByOrg?.name}</Text>
+                <Text style={{ ...styles.claimedByText, fontWeight: typography.weightBold, }}>{issue.claimedByOrg?.name}</Text>
               </View>
             </View>
           </View>

--- a/shared/src/enums/user.ts
+++ b/shared/src/enums/user.ts
@@ -1,0 +1,9 @@
+// shared/src/enums/issue.ts
+
+export type UserRole =
+    | 'REPORTER'
+    | 'ADMIN'
+
+export type OrgRole =
+    | 'ORG_ADMIN'
+    | 'ORG_MEMBER'

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -1,5 +1,6 @@
 // shared/src/types/api.ts
 import { IssueCategory, IssueStatus } from "../enums/issue";
+import { OrgRole } from "../enums/organization";
 import { PhotoMetadataSource } from "../utils/photoMetadata";
 import { User } from "./user";
 
@@ -24,6 +25,12 @@ export interface CreateIssueDTO {
     locationSource?: PhotoMetadataSource;
     photoTakenAt?: string;
     photoTakenAtSource?: PhotoMetadataSource;
+}
+
+export interface OrgMembershipDTO {
+    userId: string;
+    organizationId: string;
+    role: OrgRole;
 }
 
 export interface PostUpdateDTO {

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -1,7 +1,8 @@
 // shared/src/types/api.ts
 import { IssueCategory, IssueStatus } from "../enums/issue";
-import { OrgRole } from "../enums/organization";
+import { BoundarySource, OrgRole, OrgStatus, OrgTier, OrgType } from "../enums/organization";
 import { PhotoMetadataSource } from "../utils/photoMetadata";
+import { Org } from "./org";
 import { User } from "./user";
 
 export interface ApiResponse<T> {
@@ -25,6 +26,18 @@ export interface CreateIssueDTO {
     locationSource?: PhotoMetadataSource;
     photoTakenAt?: string;
     photoTakenAtSource?: PhotoMetadataSource;
+}
+
+export interface CreateOrgDTO {
+    name: string;
+    slug: string;
+    type: OrgType;
+    status: OrgStatus;
+    tier: OrgTier;
+    categoryScope: IssueCategory[];
+    boundarySource?: BoundarySource;
+    boundaryRef?: string;
+    boundarySyncedAt?: Date;
 }
 
 export interface OrgMembershipDTO {
@@ -60,6 +73,9 @@ export interface GetNearbyIssueResponse {
     distance: string
     upvoteCount: number
     author: Pick<User, 'id' | 'name' | 'profileImage'>;
+    claimedById: string;
+    claimedByUser?: Pick<User, 'id' | 'name' | 'profileImage'>;
+    claimedByOrg?: Pick<Org, 'id' | 'name' | 'profileImage'>;
 }
 
 export interface LoginDTO {

--- a/shared/src/types/issue.ts
+++ b/shared/src/types/issue.ts
@@ -1,6 +1,7 @@
 // shared/src/types/issue.ts
 import { IssueCategory, IssueStatus } from "../enums/issue";
 import { PhotoMetadataSource } from "../utils/photoMetadata";
+import { Org } from "./org";
 import { User } from "./user";
 
 export interface Issue {
@@ -23,6 +24,9 @@ export interface Issue {
     photoTakenAt?: string;
     photoTakenAtSource?: PhotoMetadataSource;
     author: Pick<User, 'id' | 'name' | 'profileImage'>;
+    claimedById: string;
+    claimedByUser?: Pick<User, 'id' | 'name' | 'profileImage'>;
+    claimedByOrg?: Pick<Org, 'id' | 'name' | 'profileImage'>;
 }
 
 export interface Upvote {

--- a/shared/src/types/org.ts
+++ b/shared/src/types/org.ts
@@ -1,0 +1,16 @@
+// shared/src/types/user.ts
+
+import { IssueCategory } from "../enums/issue";
+import { OrgStatus, OrgType } from "../enums/organization";
+import { UserRole } from "../enums/user";
+
+export interface Org {
+    id: string,
+    name: string,
+    profileImage: string,
+    createdAt: string,
+    type: OrgType,
+    status: OrgStatus;
+    categoryScope: IssueCategory[];
+    //add geofence later
+}

--- a/shared/src/types/user.ts
+++ b/shared/src/types/user.ts
@@ -1,9 +1,12 @@
 // shared/src/types/user.ts
 
+import { UserRole } from "../enums/user";
+
 export interface User {
     id: string,
     name: string,
     profileImage: string,
     createdAt: string,
     email: string,
+    role: UserRole;
 }


### PR DESCRIPTION
Issue #219 

**Files**
* `shared/src/types/org.ts` - org tyoes
* `shared/src/enums/user.ts` - role enums
* add claim and release issue routes
  * `backend/src/controllers/issue.controller.ts` 
  * `backend/src/repositories/issue.repository.ts`
  * `backend/src/routes/issue.routes.ts`
  * `backend/src/services/issue.service.ts`
  * `mobile/src/api/issues.ts`
* add org routes
  * `backend/src/controllers/org.controller.ts`
  * `backend/src/repositories/org.repository.ts`
  * `backend/src/routes/o 0 rg.routes.ts`
  * `backend/src/server.ts`
  * `backend/src/services/org.service.ts`
  * `mobile/src/api/orgs.ts`
* add membership routes
  * `backend/src/repositories/membership.repository.ts`
  * `backend/src/services/membership.service.ts`
* `backend/src/db/schema.ts` - add `claimedById `to issues and `profileImage` to organizations
* `backend/src/middleware/authorize.middleware.ts` - add permissions check for responder actions
* `backend/src/repositories/login.repository.ts` - add role to login return object
* `backend/src/services/timeline.service.ts` - added user info to return
* `mobile/src/api/index.ts` - added `orgsApi`
* `mobile/src/components/IssueCard.tsx` - added profile pic for claiming organization
* added on focus repo call so info is up to date
  * `mobile/src/components/IssueSquare.tsx`
  * `mobile/src/components/CalloutPopup.tsx`
* `mobile/src/components/TimelineEntry.tsx` - removed unnecessary  repo call
* `mobile/src/contexts/AuthContext.tsx` - getting user role and optional org
* `shared/src/types/issue.ts` - added claimedBy info

Note: checks and filtering for geofencing have not been implemented yet

**To Test:** 
Firstly, regenerate and reset database
`npm run db:generate`
`npm run db:reset`

**Backend**
Login with
`TOKEN=$(curl -X POST http://localhost:3000/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"Fake@email.com","password":"fakepw11"}' \
  | jq -r '.token')`
with your email and password

Claim Issue
`curl -X POST http://localhost:3000/api/issues/<issue id>/claim\
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"userId":"<userId>"}'`

Create Org
`curl -X POST http://localhost:3000/api/organizations/ \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"Test Org", "slug": "test-org", "type": "NONPROFIT", "status": "ACTIVE", "tier": "GROWTH", "categoryScope": ["POTHOLE", "GRAFFITI"]}'`
*makes current account an admin, auto creates membership

Create Membership
`curl -X POST http://localhost:3000/api/organizations/createMembeship \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"userId": "<userId>", "organizationId": "<orgId>", "role": "ORG_MEMBER" }'`

Get Org By Id
`curl -X GET http://localhost:3000/api/organizations/<orgId>/getOrgById \
  -H "Authorization: Bearer $TOKEN" \`

Get Org By user Id (user being a member)
`curl -X GET http://localhost:3000/api/organizations/<userId>/getOrgByUserId\
  -H "Authorization: Bearer $TOKEN" \`

Get Memberships by org Id
`curl -X GET http://localhost:3000/api/organizations/<orgId>/getMembershipsbyOrgId\
  -H "Authorization: Bearer $TOKEN" \`

Get Memberships by user id
`curl -X GET http://localhost:3000/api/organizations/<userId>/getMembershipByUserId\
  -H "Authorization: Bearer $TOKEN" \`

**Frontend**
use console to create an organization. the account you are signed in as will become that org's admin. open an issue and see new buttons.
* hit claim to claim issue, status will become acknowledged and a timeline entry will be entered. the button will become update, which does not currently function
* once claimed, scroll down to see an unclaim button, click it to unclaim the issue. a popup will appear asking if you're sure and if you want to add a note. the issue will go back to reported and a timeline entry with the optional message will appear.
* if you add an image with the org, the image will show up in the issue card and on the detail screen